### PR TITLE
Channels, guilds, invites, helper methods

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/Category.java
+++ b/src/main/java/com/mewna/catnip/entity/Category.java
@@ -1,5 +1,9 @@
 package com.mewna.catnip.entity;
 
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
 public interface Category extends Channel {
     @Override
     default boolean isText() {

--- a/src/main/java/com/mewna/catnip/entity/Category.java
+++ b/src/main/java/com/mewna/catnip/entity/Category.java
@@ -1,0 +1,18 @@
+package com.mewna.catnip.entity;
+
+public interface Category extends Channel {
+    @Override
+    default boolean isText() {
+        return false;
+    }
+    
+    @Override
+    default boolean isVoice() {
+        return false;
+    }
+    
+    @Override
+    default boolean isCategory() {
+        return true;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/Category.java
+++ b/src/main/java/com/mewna/catnip/entity/Category.java
@@ -6,7 +6,7 @@ import javax.annotation.CheckReturnValue;
  * @author natanbc
  * @since 9/12/18
  */
-public interface Category extends Channel {
+public interface Category extends GuildChannel {
     @Override
     @CheckReturnValue
     default boolean isText() {

--- a/src/main/java/com/mewna/catnip/entity/Category.java
+++ b/src/main/java/com/mewna/catnip/entity/Category.java
@@ -1,21 +1,26 @@
 package com.mewna.catnip.entity;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * @author natanbc
  * @since 9/12/18
  */
 public interface Category extends Channel {
     @Override
+    @CheckReturnValue
     default boolean isText() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isVoice() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isCategory() {
         return true;
     }

--- a/src/main/java/com/mewna/catnip/entity/Channel.java
+++ b/src/main/java/com/mewna/catnip/entity/Channel.java
@@ -1,0 +1,115 @@
+package com.mewna.catnip.entity;
+
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+@SuppressWarnings("ClassReferencesSubclass")
+public interface Channel extends Snowflake {
+    ChannelType type();
+    
+    default boolean isText() {
+        return type() == ChannelType.TEXT;
+    }
+    
+    default boolean isVoice() {
+        return type() == ChannelType.VOICE;
+    }
+    
+    default boolean isCategory() {
+        return type() == ChannelType.CATEGORY;
+    }
+    
+    default boolean isGuild() {
+        return type().isGuild();
+    }
+    
+    default boolean isUserDM() {
+        return type() == ChannelType.DM;
+    }
+    
+    default boolean isGroupDM() {
+        return type() == ChannelType.GROUP_DM;
+    }
+    
+    default boolean isDM() {
+        return !type().isGuild();
+    }
+    
+    default GuildChannel asGuildChannel() {
+        if(!isGuild()) {
+            throw new UnsupportedOperationException("Not a guild channel");
+        }
+        return (GuildChannel)this;
+    }
+    
+    default TextChannel asTextChannel() {
+        if(!isText()) {
+            throw new UnsupportedOperationException("Not a text channel");
+        }
+        return (TextChannel)this;
+    }
+    
+    default VoiceChannel asVoiceChannel() {
+        if(!isVoice()) {
+            throw new UnsupportedOperationException("Not a voice channel");
+        }
+        return (VoiceChannel)this;
+    }
+    
+    default Category asCategory() {
+        if(!isCategory()) {
+            throw new UnsupportedOperationException("Not a category");
+        }
+        return (Category)this;
+    }
+    
+    default DMChannel asDMChannel() {
+        if(!isDM()) {
+            throw new UnsupportedOperationException("Not a DM channel");
+        }
+        return (DMChannel)this;
+    }
+    
+    default UserDMChannel asUserDMChannel() {
+        if(!isUserDM()) {
+            throw new UnsupportedOperationException("Not an user DM channel");
+        }
+        return (UserDMChannel)this;
+    }
+    
+    default GroupDMChannel asGroupDMChannel() {
+        if(!isGroupDM()) {
+            throw new UnsupportedOperationException("Not a group DM channel");
+        }
+        return (GroupDMChannel)this;
+    }
+    
+    enum ChannelType {
+        TEXT(0, true), DM(1, false), VOICE(2, true), GROUP_DM(3, false), CATEGORY(4, true);
+        
+        @Getter
+        private final int key;
+        @Getter
+        private final boolean guild;
+        
+        ChannelType(final int key, final boolean guild) {
+            this.key = key;
+            this.guild = guild;
+        }
+    
+        @Nonnull
+        public static ChannelType byKey(final int key) {
+            for(final ChannelType level : values()) {
+                if(level.key == key) {
+                    return level;
+                }
+            }
+            throw new IllegalArgumentException("No channel type for key " + key);
+        }
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/Channel.java
+++ b/src/main/java/com/mewna/catnip/entity/Channel.java
@@ -2,6 +2,7 @@ package com.mewna.catnip.entity;
 
 import lombok.Getter;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
@@ -11,40 +12,52 @@ import java.util.concurrent.CompletableFuture;
  */
 @SuppressWarnings("ClassReferencesSubclass")
 public interface Channel extends Snowflake {
+    @Nonnull
+    @CheckReturnValue
     ChannelType type();
     
+    @Nonnull
     default CompletableFuture<Channel> delete() {
         return catnip().rest().channel().deleteChannel(id());
     }
     
+    @CheckReturnValue
     default boolean isText() {
         return type() == ChannelType.TEXT;
     }
     
+    @CheckReturnValue
     default boolean isVoice() {
         return type() == ChannelType.VOICE;
     }
     
+    @CheckReturnValue
     default boolean isCategory() {
         return type() == ChannelType.CATEGORY;
     }
     
+    @CheckReturnValue
     default boolean isGuild() {
         return type().isGuild();
     }
     
+    @CheckReturnValue
     default boolean isUserDM() {
         return type() == ChannelType.DM;
     }
     
+    @CheckReturnValue
     default boolean isGroupDM() {
         return type() == ChannelType.GROUP_DM;
     }
     
+    @CheckReturnValue
     default boolean isDM() {
         return !type().isGuild();
     }
     
+    @Nonnull
+    @CheckReturnValue
     default GuildChannel asGuildChannel() {
         if(!isGuild()) {
             throw new UnsupportedOperationException("Not a guild channel");
@@ -52,6 +65,8 @@ public interface Channel extends Snowflake {
         return (GuildChannel)this;
     }
     
+    @Nonnull
+    @CheckReturnValue
     default TextChannel asTextChannel() {
         if(!isText()) {
             throw new UnsupportedOperationException("Not a text channel");
@@ -59,6 +74,8 @@ public interface Channel extends Snowflake {
         return (TextChannel)this;
     }
     
+    @Nonnull
+    @CheckReturnValue
     default VoiceChannel asVoiceChannel() {
         if(!isVoice()) {
             throw new UnsupportedOperationException("Not a voice channel");
@@ -66,6 +83,8 @@ public interface Channel extends Snowflake {
         return (VoiceChannel)this;
     }
     
+    @Nonnull
+    @CheckReturnValue
     default Category asCategory() {
         if(!isCategory()) {
             throw new UnsupportedOperationException("Not a category");
@@ -73,6 +92,8 @@ public interface Channel extends Snowflake {
         return (Category)this;
     }
     
+    @Nonnull
+    @CheckReturnValue
     default DMChannel asDMChannel() {
         if(!isDM()) {
             throw new UnsupportedOperationException("Not a DM channel");
@@ -80,6 +101,8 @@ public interface Channel extends Snowflake {
         return (DMChannel)this;
     }
     
+    @Nonnull
+    @CheckReturnValue
     default UserDMChannel asUserDMChannel() {
         if(!isUserDM()) {
             throw new UnsupportedOperationException("Not an user DM channel");
@@ -87,6 +110,8 @@ public interface Channel extends Snowflake {
         return (UserDMChannel)this;
     }
     
+    @Nonnull
+    @CheckReturnValue
     default GroupDMChannel asGroupDMChannel() {
         if(!isGroupDM()) {
             throw new UnsupportedOperationException("Not a group DM channel");

--- a/src/main/java/com/mewna/catnip/entity/Channel.java
+++ b/src/main/java/com/mewna/catnip/entity/Channel.java
@@ -3,6 +3,7 @@ package com.mewna.catnip.entity;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author natanbc
@@ -11,6 +12,10 @@ import javax.annotation.Nonnull;
 @SuppressWarnings("ClassReferencesSubclass")
 public interface Channel extends Snowflake {
     ChannelType type();
+    
+    default CompletableFuture<Channel> delete() {
+        return catnip().rest().channel().deleteChannel(id());
+    }
     
     default boolean isText() {
         return type() == ChannelType.TEXT;

--- a/src/main/java/com/mewna/catnip/entity/CreatedInvite.java
+++ b/src/main/java/com/mewna/catnip/entity/CreatedInvite.java
@@ -1,0 +1,16 @@
+package com.mewna.catnip.entity;
+
+import java.time.OffsetDateTime;
+
+/**
+ * @author natanbc
+ * @since 9/14/18
+ */
+public interface CreatedInvite extends Invite {
+    int uses();
+    int maxUses();
+    int maxAge();
+    boolean temporary();
+    OffsetDateTime createdAt();
+    boolean revoked();
+}

--- a/src/main/java/com/mewna/catnip/entity/DMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/DMChannel.java
@@ -1,0 +1,32 @@
+package com.mewna.catnip.entity;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+public interface DMChannel extends Channel {
+    @Override
+    default boolean isDM() {
+        return true;
+    }
+    
+    @Override
+    default boolean isGuild() {
+        return false;
+    }
+    
+    @Override
+    default boolean isText() {
+        return false;
+    }
+    
+    @Override
+    default boolean isVoice() {
+        return false;
+    }
+    
+    @Override
+    default boolean isCategory() {
+        return false;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/DMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/DMChannel.java
@@ -1,31 +1,38 @@
 package com.mewna.catnip.entity;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * @author natanbc
  * @since 9/12/18
  */
-public interface DMChannel extends Channel, MessageChannel {
+public interface DMChannel extends MessageChannel {
     @Override
+    @CheckReturnValue
     default boolean isDM() {
         return true;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isGuild() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isText() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isVoice() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isCategory() {
         return false;
     }

--- a/src/main/java/com/mewna/catnip/entity/DMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/DMChannel.java
@@ -4,7 +4,7 @@ package com.mewna.catnip.entity;
  * @author natanbc
  * @since 9/12/18
  */
-public interface DMChannel extends Channel {
+public interface DMChannel extends Channel, MessageChannel {
     @Override
     default boolean isDM() {
         return true;

--- a/src/main/java/com/mewna/catnip/entity/GroupDMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/GroupDMChannel.java
@@ -1,0 +1,24 @@
+package com.mewna.catnip.entity;
+
+import java.util.List;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+public interface GroupDMChannel extends DMChannel {
+    List<User> recipients();
+    String icon();
+    String ownerId();
+    String applicationId();
+    
+    @Override
+    default boolean isUserDM() {
+        return false;
+    }
+    
+    @Override
+    default boolean isGroupDM() {
+        return true;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/GroupDMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/GroupDMChannel.java
@@ -1,5 +1,7 @@
 package com.mewna.catnip.entity;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -7,17 +9,28 @@ import java.util.List;
  * @since 9/12/18
  */
 public interface GroupDMChannel extends DMChannel {
+    @Nonnull
+    @CheckReturnValue
     List<User> recipients();
+    
+    @CheckReturnValue
     String icon();
+    
+    @Nonnull
+    @CheckReturnValue
     String ownerId();
+    
+    @CheckReturnValue
     String applicationId();
     
     @Override
+    @CheckReturnValue
     default boolean isUserDM() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isGroupDM() {
         return true;
     }

--- a/src/main/java/com/mewna/catnip/entity/Guild.java
+++ b/src/main/java/com/mewna/catnip/entity/Guild.java
@@ -140,9 +140,12 @@ public interface Guild extends Snowflake {
     @CheckReturnValue
     List<Member> members();
     
+    @Nonnull
+    @CheckReturnValue
+    List<Channel> channels();
+    
     /* TODO:
         - voice_states
-        - channels
         - presences
      */
     

--- a/src/main/java/com/mewna/catnip/entity/Guild.java
+++ b/src/main/java/com/mewna/catnip/entity/Guild.java
@@ -10,8 +10,10 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author natanbc
@@ -148,6 +150,53 @@ public interface Guild extends Snowflake {
         - voice_states
         - presences
      */
+    
+    default CompletableFuture<List<Role>> fetchRoles() {
+        return catnip().rest().guild().getGuildRoles(id());
+    }
+    
+    default CompletableFuture<List<GuildChannel>> fetchChannels() {
+        return catnip().rest().guild().getGuildChannels(id());
+    }
+    
+    default CompletableFuture<List<CreatedInvite>> fetchInvites() {
+        return catnip().rest().guild().getGuildInvites(id());
+    }
+    
+    default CompletableFuture<List<CustomEmoji>> fetchEmojis() {
+        return catnip().rest().emoji().listGuildEmojis(id());
+    }
+    
+    default CompletableFuture<CustomEmoji> fetchEmoji(@Nonnull final String emojiId) {
+        return catnip().rest().emoji().getGuildEmoji(id(), emojiId);
+    }
+    
+    default CompletableFuture<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final byte[] image,
+                                                       @Nonnull final Collection<String> roles) {
+        return catnip().rest().emoji().createGuildEmoji(id(), name, image, roles);
+    }
+    
+    default CompletableFuture<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final String base64Image,
+                                                       @Nonnull final Collection<String> roles) {
+        return catnip().rest().emoji().createGuildEmoji(id(), name, base64Image, roles);
+    }
+    
+    default CompletableFuture<CustomEmoji> modifyEmoji(@Nonnull final String emojiId, @Nonnull final String name,
+                                                       @Nonnull final Collection<String> roles) {
+        return catnip().rest().emoji().modifyGuildEmoji(id(), emojiId, name, roles);
+    }
+    
+    default CompletableFuture<Void> deleteEmoji(@Nonnull final String emojiId) {
+        return catnip().rest().emoji().deleteGuildEmoji(id(), emojiId);
+    }
+    
+    default CompletableFuture<Void> leave() {
+        return catnip().rest().user().leaveGuild(id());
+    }
+    
+    default CompletableFuture<Void> delete() {
+        return catnip().rest().guild().deleteGuild(id());
+    }
     
     enum NotificationLevel {
         ALL_MESSAGES(0),

--- a/src/main/java/com/mewna/catnip/entity/Guild.java
+++ b/src/main/java/com/mewna/catnip/entity/Guild.java
@@ -151,49 +151,71 @@ public interface Guild extends Snowflake {
         - presences
      */
     
+    @Nonnull
+    @CheckReturnValue
     default CompletableFuture<List<Role>> fetchRoles() {
         return catnip().rest().guild().getGuildRoles(id());
     }
     
+    @Nonnull
+    @CheckReturnValue
     default CompletableFuture<List<GuildChannel>> fetchChannels() {
         return catnip().rest().guild().getGuildChannels(id());
     }
     
+    @Nonnull
+    @CheckReturnValue
     default CompletableFuture<List<CreatedInvite>> fetchInvites() {
         return catnip().rest().guild().getGuildInvites(id());
     }
     
+    @Nonnull
+    @CheckReturnValue
+    default CompletableFuture<List<Webhook>> fetchWebhooks() {
+        return catnip().rest().webhook().getGuildWebhooks(id());
+    }
+    
+    @Nonnull
+    @CheckReturnValue
     default CompletableFuture<List<CustomEmoji>> fetchEmojis() {
         return catnip().rest().emoji().listGuildEmojis(id());
     }
     
+    @Nonnull
+    @CheckReturnValue
     default CompletableFuture<CustomEmoji> fetchEmoji(@Nonnull final String emojiId) {
         return catnip().rest().emoji().getGuildEmoji(id(), emojiId);
     }
     
+    @Nonnull
     default CompletableFuture<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final byte[] image,
                                                        @Nonnull final Collection<String> roles) {
         return catnip().rest().emoji().createGuildEmoji(id(), name, image, roles);
     }
     
+    @Nonnull
     default CompletableFuture<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final String base64Image,
                                                        @Nonnull final Collection<String> roles) {
         return catnip().rest().emoji().createGuildEmoji(id(), name, base64Image, roles);
     }
     
+    @Nonnull
     default CompletableFuture<CustomEmoji> modifyEmoji(@Nonnull final String emojiId, @Nonnull final String name,
                                                        @Nonnull final Collection<String> roles) {
         return catnip().rest().emoji().modifyGuildEmoji(id(), emojiId, name, roles);
     }
     
+    @Nonnull
     default CompletableFuture<Void> deleteEmoji(@Nonnull final String emojiId) {
         return catnip().rest().emoji().deleteGuildEmoji(id(), emojiId);
     }
     
+    @Nonnull
     default CompletableFuture<Void> leave() {
         return catnip().rest().user().leaveGuild(id());
     }
     
+    @Nonnull
     default CompletableFuture<Void> delete() {
         return catnip().rest().guild().deleteGuild(id());
     }

--- a/src/main/java/com/mewna/catnip/entity/Guild.java
+++ b/src/main/java/com/mewna/catnip/entity/Guild.java
@@ -1,9 +1,14 @@
 package com.mewna.catnip.entity;
 
+import com.mewna.catnip.Catnip;
 import com.mewna.catnip.entity.Emoji.CustomEmoji;
-import com.mewna.catnip.entity.impl.Permission;
+import com.mewna.catnip.entity.util.Permission;
 import com.mewna.catnip.entity.util.ImageOptions;
+import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnegative;
@@ -12,6 +17,7 @@ import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -220,6 +226,12 @@ public interface Guild extends Snowflake {
         return catnip().rest().guild().deleteGuild(id());
     }
     
+    @Nonnull
+    @CheckReturnValue
+    default GuildEditFields edit() {
+        return new GuildEditFields(this);
+    }
+    
     enum NotificationLevel {
         ALL_MESSAGES(0),
         ONLY_MENTIONS(1);
@@ -309,6 +321,80 @@ public interface Guild extends Snowflake {
                 }
             }
             throw new IllegalArgumentException("No verification level for key " + key);
+        }
+    }
+    
+    @Getter
+    @Setter
+    @Accessors(fluent = true)
+    class GuildEditFields {
+        private final Guild guild;
+        private String name;
+        private String region;
+        private VerificationLevel verificationLevel;
+        private NotificationLevel defaultMessageNotifications;
+        private ContentFilterLevel explicitContentFilter;
+        private String afkChannelId;
+        private Integer afkTimeout;
+        private String icon;
+        private String ownerId;
+        private String splash;
+        private String systemChannelId;
+        
+        public GuildEditFields(@Nullable final Guild guild) {
+            this.guild = guild;
+        }
+    
+        public GuildEditFields() {
+            this(null);
+        }
+        
+        @Nonnull
+        public CompletableFuture<Guild> submit() {
+            if(guild == null) {
+                throw new IllegalStateException("Cannot submit edit without a guild object! Please use RestGuild directly instead");
+            }
+            return guild.catnip().rest().guild().modifyGuild(guild.id(), this);
+        }
+    
+        @Nonnull
+        @CheckReturnValue
+        public JsonObject payload() {
+            final JsonObject payload = new JsonObject();
+            if(name != null && (guild == null || !Objects.equals(name, guild.name()))) {
+                payload.put("name", name);
+            }
+            if(region != null && (guild == null || !Objects.equals(region, guild.region()))) {
+                payload.put("region", region);
+            }
+            if(verificationLevel != null && (guild == null || !Objects.equals(verificationLevel, guild.verificationLevel()))) {
+                payload.put("verification_level", verificationLevel.getKey());
+            }
+            if(defaultMessageNotifications != null && (guild == null || !Objects.equals(defaultMessageNotifications, guild.defaultMessageNotifications()))) {
+                payload.put("default_message_notifications", defaultMessageNotifications.getKey());
+            }
+            if(explicitContentFilter != null && (guild == null || !Objects.equals(explicitContentFilter, guild.explicitContentFilter()))) {
+                payload.put("explicit_content_filter", explicitContentFilter.getKey());
+            }
+            if(afkChannelId != null && (guild == null || !Objects.equals(afkChannelId, guild.afkChannelId()))) {
+                payload.put("afk_channel_id", afkChannelId);
+            }
+            if(afkTimeout != null && (guild == null || !Objects.equals(afkTimeout, guild.afkTimeout()))) {
+                payload.put("afk_timeout", afkTimeout);
+            }
+            if(icon != null && (guild == null || !Objects.equals(icon, guild.icon()))) {
+                payload.put("icon", icon);
+            }
+            if(ownerId != null && (guild == null || !Objects.equals(ownerId, guild.ownerId()))) {
+                payload.put("owner_id", ownerId);
+            }
+            if(splash != null && (guild == null || !Objects.equals(splash, guild.splash()))) {
+                payload.put("splash", splash);
+            }
+            if(systemChannelId != null && (guild == null || !Objects.equals(systemChannelId, guild.systemChannelId()))) {
+                payload.put("system_channel_id", systemChannelId);
+            }
+            return payload;
         }
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/GuildChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/GuildChannel.java
@@ -1,5 +1,13 @@
 package com.mewna.catnip.entity;
 
+import com.mewna.catnip.rest.invite.InviteCreateOptions;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 /**
  * @author natanbc
  * @since 9/12/18
@@ -28,5 +36,23 @@ public interface GuildChannel extends Channel {
     @Override
     default GuildChannel asGuildChannel() {
         return this;
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    default CompletableFuture<CreatedInvite> createInvite(@Nullable final InviteCreateOptions options) {
+        return catnip().rest().channel().createInvite(id(), options);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    default CompletableFuture<CreatedInvite> createInvite() {
+        return createInvite(null);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    default CompletableFuture<List<CreatedInvite>> fetchInvites() {
+        return catnip().rest().channel().getChannelInvites(id());
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/GuildChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/GuildChannel.java
@@ -1,0 +1,32 @@
+package com.mewna.catnip.entity;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+public interface GuildChannel extends Channel {
+    String name();
+    String guildId();
+    int position();
+    String parentId();
+    
+    @Override
+    default boolean isDM() {
+        return false;
+    }
+    
+    @Override
+    default boolean isGroupDM() {
+        return false;
+    }
+    
+    @Override
+    default boolean isGuild() {
+        return true;
+    }
+    
+    @Override
+    default GuildChannel asGuildChannel() {
+        return this;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/GuildChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/GuildChannel.java
@@ -1,12 +1,22 @@
 package com.mewna.catnip.entity;
 
+import com.mewna.catnip.entity.PermissionOverride.OverrideType;
+import com.mewna.catnip.rest.guild.PermissionOverrideData;
 import com.mewna.catnip.rest.invite.InviteCreateOptions;
+import io.vertx.core.json.JsonObject;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 /**
  * @author natanbc
@@ -27,6 +37,10 @@ public interface GuildChannel extends Channel {
     @Nullable
     @CheckReturnValue
     String parentId();
+    
+    @Nonnull
+    @CheckReturnValue
+    List<PermissionOverride> overrides();
     
     @Override
     @CheckReturnValue
@@ -62,5 +76,133 @@ public interface GuildChannel extends Channel {
     @CheckReturnValue
     default CompletableFuture<List<CreatedInvite>> fetchInvites() {
         return catnip().rest().channel().getChannelInvites(id());
+    }
+    
+    @Getter
+    @Setter
+    @Accessors(fluent = true)
+    class ChannelEditFields {
+        private final GuildChannel channel;
+        
+        public ChannelEditFields(@Nullable final GuildChannel channel) {
+            this.channel = channel;
+        }
+        
+        public ChannelEditFields() {
+            this(null);
+        }
+        
+        private String name;
+        private Integer position;
+        private String topic;
+        private Boolean nsfw;
+        private Integer bitrate;
+        private Integer userLimit;
+        private Map<String, PermissionOverrideData> overrides = new HashMap<>();
+        private String parentId;
+    
+        @Nonnull
+        @CheckReturnValue
+        public PermissionOverrideData override(@Nonnull final String id, @Nonnull final OverrideType type) {
+            return overrides.computeIfAbsent(id, __ -> new PermissionOverrideData(type, id));
+        }
+    
+        @Nonnull
+        @CheckReturnValue
+        public PermissionOverrideData memberOverride(@Nonnull final String id) {
+            return override(id, OverrideType.MEMBER);
+        }
+    
+        @Nonnull
+        @CheckReturnValue
+        public PermissionOverrideData roleOverride(@Nonnull final String id) {
+            return override(id, OverrideType.ROLE);
+        }
+    
+        @Nonnull
+        public ChannelEditFields override(@Nonnull final String id, @Nonnull final OverrideType type, @Nonnull final Consumer<PermissionOverrideData> configurator) {
+            configurator.accept(override(id, type));
+            return this;
+        }
+    
+        @Nonnull
+        public ChannelEditFields memberOverride(@Nonnull final String id, @Nonnull final Consumer<PermissionOverrideData> configurator) {
+            return override(id, OverrideType.MEMBER, configurator);
+        }
+    
+        @Nonnull
+        public ChannelEditFields roleOverride(@Nonnull final String id, @Nonnull final Consumer<PermissionOverrideData> configurator) {
+            return override(id, OverrideType.ROLE, configurator);
+        }
+    
+        @Nonnull
+        public CompletableFuture<GuildChannel> submit() {
+            if(channel == null) {
+                throw new IllegalStateException("Cannot submit edit without a channel object! Please use RestChannel directly instead");
+            }
+            return channel.catnip().rest().channel().modifyChannel(channel.id(), this);
+        }
+        
+        @Nonnull
+        @CheckReturnValue
+        public JsonObject payload() {
+            final JsonObject payload = new JsonObject();
+            if(name != null && (channel == null || !Objects.equals(name, channel.name()))) {
+                payload.put("name", name);
+            }
+            if(position != null && (channel == null || !Objects.equals(position, channel.position()))) {
+                payload.put("position", position);
+            }
+            if(parentId != null && (channel == null || !Objects.equals(parentId, channel.parentId()))) {
+                payload.put("parent_id", parentId);
+            }
+            if(overrides != null && !overrides.isEmpty()) {
+                final Map<String, PermissionOverrideData> finalOverrides = new HashMap<>();
+                if(channel != null) {
+                    channel.overrides().forEach(override -> {
+                        finalOverrides.put(override.id(), PermissionOverrideData.create(override));
+                    });
+                }
+                overrides.forEach(finalOverrides::put);
+                final JsonObject object = new JsonObject();
+                finalOverrides.forEach((k, v) -> {
+                    object.put(k, v.toJson());
+                });
+                payload.put("permission_overwrites", object);
+            }
+            if(channel != null) {
+                if(channel.isText()) {
+                    final TextChannel text = channel.asTextChannel();
+                    if(topic != null && !Objects.equals(topic, text.topic())) {
+                        payload.put("topic", topic);
+                    }
+                    if(nsfw != null && !Objects.equals(nsfw, text.nsfw())) {
+                        payload.put("nsfw", nsfw);
+                    }
+                } else if(channel.isVoice()) {
+                    final VoiceChannel voice = channel.asVoiceChannel();
+                    if(bitrate != null && !Objects.equals(bitrate, voice.bitrate())) {
+                        payload.put("bitrate", bitrate);
+                    }
+                    if(userLimit != null && !Objects.equals(userLimit, voice.userLimit())) {
+                        payload.put("user_limit", userLimit);
+                    }
+                }
+            } else {
+                if(topic != null) {
+                    payload.put("topic", topic);
+                }
+                if(nsfw != null) {
+                    payload.put("nsfw", nsfw);
+                }
+                if(bitrate != null) {
+                    payload.put("bitrate", bitrate);
+                }
+                if(userLimit != null) {
+                    payload.put("user_limit", userLimit);
+                }
+            }
+            return payload;
+        }
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/GuildChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/GuildChannel.java
@@ -13,29 +13,37 @@ import java.util.concurrent.CompletableFuture;
  * @since 9/12/18
  */
 public interface GuildChannel extends Channel {
+    @Nonnull
+    @CheckReturnValue
     String name();
+    
+    @Nonnull
+    @CheckReturnValue
     String guildId();
+    
+    @CheckReturnValue
     int position();
+    
+    @Nullable
+    @CheckReturnValue
     String parentId();
     
     @Override
+    @CheckReturnValue
     default boolean isDM() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isGroupDM() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isGuild() {
         return true;
-    }
-    
-    @Override
-    default GuildChannel asGuildChannel() {
-        return this;
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/entity/Invite.java
+++ b/src/main/java/com/mewna/catnip/entity/Invite.java
@@ -8,6 +8,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author natanbc
@@ -20,6 +21,10 @@ public interface Invite extends Entity {
     InviteChannel channel();
     int approximatePresenceCount();
     int approximateMemberCount();
+    
+    default CompletableFuture<Invite> delete() {
+        return catnip().rest().invite().deleteInvite(code());
+    }
     
     interface Inviter extends Snowflake {
         @Nonnull

--- a/src/main/java/com/mewna/catnip/entity/Invite.java
+++ b/src/main/java/com/mewna/catnip/entity/Invite.java
@@ -1,0 +1,120 @@
+package com.mewna.catnip.entity;
+
+import com.mewna.catnip.entity.Channel.ChannelType;
+import com.mewna.catnip.entity.Guild.VerificationLevel;
+import com.mewna.catnip.entity.util.ImageOptions;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * @author natanbc
+ * @since 9/14/18
+ */
+public interface Invite extends Entity {
+    String code();
+    Inviter inviter();
+    InviteGuild guild();
+    InviteChannel channel();
+    int approximatePresenceCount();
+    int approximateMemberCount();
+    
+    interface Inviter extends Snowflake {
+        @Nonnull
+        @CheckReturnValue
+        String id();
+        
+        @Nonnull
+        @CheckReturnValue
+        String username();
+    
+        @Nonnull
+        @CheckReturnValue
+        String discriminator();
+        
+        @Nonnull
+        @CheckReturnValue
+        String avatar();
+        
+        @CheckReturnValue
+        boolean animatedAvatar();
+    
+        @Nonnull
+        @CheckReturnValue
+        String defaultAvatarUrl();
+        
+        @Nullable
+        @CheckReturnValue
+        String avatarUrl(@Nonnull ImageOptions options);
+        @Nullable
+        @CheckReturnValue
+        String avatarUrl();
+    
+        @Nonnull
+        @CheckReturnValue
+        String effectiveAvatarUrl(@Nonnull ImageOptions options);
+        @Nonnull
+        @CheckReturnValue
+        String effectiveAvatarUrl();
+    }
+    
+    interface InviteGuild extends Snowflake {
+        @Nonnull
+        @CheckReturnValue
+        String id();
+    
+        @Nonnull
+        @CheckReturnValue
+        String name();
+    
+        @Nullable
+        @CheckReturnValue
+        String icon();
+    
+        @Nullable
+        @CheckReturnValue
+        String splash();
+        
+        @Nonnull
+        @CheckReturnValue
+        List<String> features();
+        
+        @Nonnull
+        @CheckReturnValue
+        VerificationLevel verificationLevel();
+    
+        @Nullable
+        @CheckReturnValue
+        String iconUrl(@Nonnull ImageOptions options);
+        @Nullable
+        @CheckReturnValue
+        default String iconUrl() {
+            return iconUrl(new ImageOptions());
+        }
+    
+        @Nullable
+        @CheckReturnValue
+        String splashUrl(@Nonnull ImageOptions options);
+        @Nullable
+        @CheckReturnValue
+        default String splashUrl() {
+            return splashUrl(new ImageOptions());
+        }
+    }
+    
+    interface InviteChannel extends Snowflake {
+        @Nonnull
+        @CheckReturnValue
+        String id();
+    
+        @Nonnull
+        @CheckReturnValue
+        String name();
+        
+        @Nonnull
+        @CheckReturnValue
+        ChannelType type();
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/Invite.java
+++ b/src/main/java/com/mewna/catnip/entity/Invite.java
@@ -15,13 +15,26 @@ import java.util.concurrent.CompletableFuture;
  * @since 9/14/18
  */
 public interface Invite extends Entity {
+    @Nonnull
+    @CheckReturnValue
     String code();
+    
+    @Nonnull
+    @CheckReturnValue
     Inviter inviter();
+    
+    @Nonnull
+    @CheckReturnValue
     InviteGuild guild();
+    
+    @Nonnull
+    @CheckReturnValue
     InviteChannel channel();
+    
     int approximatePresenceCount();
     int approximateMemberCount();
     
+    @Nonnull
     default CompletableFuture<Invite> delete() {
         return catnip().rest().invite().deleteInvite(code());
     }

--- a/src/main/java/com/mewna/catnip/entity/Member.java
+++ b/src/main/java/com/mewna/catnip/entity/Member.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author amy
@@ -60,4 +61,13 @@ public interface Member extends Snowflake {
      */
     @Nonnull
     OffsetDateTime joinedAt();
+    
+    /**
+     * Creates a DM channel with this member's user.
+     *
+     * @return Future with the result of the DM creation.
+     */
+    default CompletableFuture<DMChannel> createDM() {
+        return catnip().rest().channel().createDM(id());
+    }
 }

--- a/src/main/java/com/mewna/catnip/entity/Member.java
+++ b/src/main/java/com/mewna/catnip/entity/Member.java
@@ -68,6 +68,6 @@ public interface Member extends Snowflake {
      * @return Future with the result of the DM creation.
      */
     default CompletableFuture<DMChannel> createDM() {
-        return catnip().rest().channel().createDM(id());
+        return catnip().rest().user().createDM(id());
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/Message.java
+++ b/src/main/java/com/mewna/catnip/entity/Message.java
@@ -201,6 +201,26 @@ public interface Message extends Snowflake {
         return catnip().rest().channel().addReaction(channelId(), id(), emoji);
     }
     
+    @Nonnull
+    default CompletableFuture<Void> delete() {
+        return catnip().rest().channel().deleteMessage(channelId(), id());
+    }
+    
+    @Nonnull
+    default CompletableFuture<Message> edit(@Nonnull final String content) {
+        return catnip().rest().channel().editMessage(channelId(), id(), content);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Message> edit(@Nonnull final Embed embed) {
+        return catnip().rest().channel().editMessage(channelId(), id(), embed);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Message> edit(@Nonnull final Message message) {
+        return catnip().rest().channel().editMessage(channelId(), id(), message);
+    }
+    
     interface Attachment extends Snowflake {
         /**
          * The name of the file represented by this attachment.

--- a/src/main/java/com/mewna/catnip/entity/MessageChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/MessageChannel.java
@@ -1,0 +1,73 @@
+package com.mewna.catnip.entity;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+
+public interface MessageChannel extends Channel {
+    @Nonnull
+    default CompletableFuture<Message> sendMessage(@Nonnull final String content) {
+        return catnip().rest().channel().sendMessage(id(), content);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Message> sendMessage(@Nonnull final Embed embed) {
+        return catnip().rest().channel().sendMessage(id(), embed);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Message> sendMessage(@Nonnull final Message message) {
+        return catnip().rest().channel().sendMessage(id(), message);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Message> editMessage(@Nonnull final String messageId, @Nonnull final String content) {
+        return catnip().rest().channel().editMessage(id(), messageId, content);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Message> editMessage(@Nonnull final String messageId, @Nonnull final Embed embed) {
+        return catnip().rest().channel().editMessage(id(), messageId, embed);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Message> editMessage(@Nonnull final String messageId, @Nonnull final Message message) {
+        return catnip().rest().channel().editMessage(id(), messageId, message);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Void> deleteMessage(@Nonnull final String messageId) {
+        return catnip().rest().channel().deleteMessage(id(), messageId);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Void> addReaction(@Nonnull final String messageId, @Nonnull final String emoji) {
+        return catnip().rest().channel().addReaction(id(), messageId, emoji);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Void> addReaction(@Nonnull final String messageId, @Nonnull final Emoji emoji) {
+        return catnip().rest().channel().addReaction(id(), messageId, emoji);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Void> deleteOwnReaction(@Nonnull final String messageId, @Nonnull final String emoji) {
+        return catnip().rest().channel().deleteOwnReaction(id(), messageId, emoji);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Void> deleteOwnReaction(@Nonnull final String messageId, @Nonnull final Emoji emoji) {
+        return catnip().rest().channel().deleteOwnReaction(id(), messageId, emoji);
+    }
+    
+    @Nonnull
+    default CompletableFuture<Void> triggerTypingIndicator() {
+        return catnip().rest().channel().triggerTypingIndicator(id());
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    default CompletableFuture<Message> fetchMessage(@Nonnull final String messageId) {
+        return catnip().rest().channel().getMessage(id(), messageId);
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/PermissionOverride.java
+++ b/src/main/java/com/mewna/catnip/entity/PermissionOverride.java
@@ -1,0 +1,47 @@
+package com.mewna.catnip.entity;
+
+import com.mewna.catnip.entity.util.Permission;
+import lombok.Getter;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+/**
+ * @author natanbc
+ * @since 9/15/18
+ */
+public interface PermissionOverride extends Snowflake {
+    @Nonnull
+    @CheckReturnValue
+    OverrideType type();
+    
+    @Nonnull
+    @CheckReturnValue
+    Set<Permission> allow();
+    
+    @Nonnull
+    @CheckReturnValue
+    Set<Permission> deny();
+    
+    enum OverrideType {
+        ROLE("role"), MEMBER("member");
+        
+        @Getter
+        private final String key;
+    
+        OverrideType(final String key) {
+            this.key = key;
+        }
+        
+        @Nonnull
+        public static OverrideType byKey(final String key) {
+            for(final OverrideType level : values()) {
+                if(level.key.equals(key)) {
+                    return level;
+                }
+            }
+            throw new IllegalArgumentException("No override type for key " + key);
+        }
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/Role.java
+++ b/src/main/java/com/mewna/catnip/entity/Role.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * @since 9/4/18.
  */
 @SuppressWarnings("unused")
-public interface Role {
+public interface Role extends Snowflake {
     /**
      * The unique snowflake ID of this role.
      *

--- a/src/main/java/com/mewna/catnip/entity/Role.java
+++ b/src/main/java/com/mewna/catnip/entity/Role.java
@@ -1,6 +1,6 @@
 package com.mewna.catnip.entity;
 
-import com.mewna.catnip.entity.impl.Permission;
+import com.mewna.catnip.entity.util.Permission;
 
 import javax.annotation.Nonnull;
 import java.util.Set;

--- a/src/main/java/com/mewna/catnip/entity/Snowflake.java
+++ b/src/main/java/com/mewna/catnip/entity/Snowflake.java
@@ -6,6 +6,10 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.time.OffsetDateTime;
 
+/**
+ * @author natanbc
+ * @since 5/9/18.
+ */
 public interface Snowflake extends Entity {
     /**
      * The ID of this snowflake.

--- a/src/main/java/com/mewna/catnip/entity/TextChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/TextChannel.java
@@ -1,0 +1,25 @@
+package com.mewna.catnip.entity;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+public interface TextChannel extends GuildChannel {
+    String topic();
+    boolean nsfw();
+    
+    @Override
+    default boolean isText() {
+        return true;
+    }
+    
+    @Override
+    default boolean isVoice() {
+        return false;
+    }
+    
+    @Override
+    default boolean isCategory() {
+        return false;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/TextChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/TextChannel.java
@@ -1,25 +1,44 @@
 package com.mewna.catnip.entity;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 /**
  * @author natanbc
  * @since 9/12/18
  */
 public interface TextChannel extends GuildChannel, MessageChannel {
+    @Nullable
+    @CheckReturnValue
     String topic();
+    
+    @CheckReturnValue
     boolean nsfw();
     
     @Override
+    @CheckReturnValue
     default boolean isText() {
         return true;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isVoice() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isCategory() {
         return false;
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    default CompletableFuture<List<Webhook>> fetchWebhooks() {
+        return catnip().rest().webhook().getChannelWebhooks(id());
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/TextChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/TextChannel.java
@@ -4,7 +4,7 @@ package com.mewna.catnip.entity;
  * @author natanbc
  * @since 9/12/18
  */
-public interface TextChannel extends GuildChannel {
+public interface TextChannel extends GuildChannel, MessageChannel {
     String topic();
     boolean nsfw();
     

--- a/src/main/java/com/mewna/catnip/entity/User.java
+++ b/src/main/java/com/mewna/catnip/entity/User.java
@@ -2,20 +2,22 @@ package com.mewna.catnip.entity;
 
 import com.mewna.catnip.entity.util.ImageOptions;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author amy
  * @since 9/4/18
  */
 public interface User extends Snowflake {
-    
     /**
      * Whether the user's avatar is animated.
      *
      * @return True if the avatar is animated, false otherwise.
      */
+    @CheckReturnValue
     boolean isAvatarAnimated();
     
     /**
@@ -24,6 +26,7 @@ public interface User extends Snowflake {
      * @return String containing the URL to the default avatar. Never null.
      */
     @Nonnull
+    @CheckReturnValue
     String defaultAvatarUrl();
     
     /**
@@ -37,7 +40,8 @@ public interface User extends Snowflake {
      * @return String containing the URL to their avatar, options considered. Can be null.
      */
     @Nullable
-    String avatarUrl(final ImageOptions options);
+    @CheckReturnValue
+    String avatarUrl(@Nonnull final ImageOptions options);
     
     /**
      * The URL for the user's set avatar. Can be null if the user has not set an avatar.
@@ -48,6 +52,7 @@ public interface User extends Snowflake {
      * @return String containing the URL to their avatar. Can be null.
      */
     @Nullable
+    @CheckReturnValue
     String avatarUrl();
     
     /**
@@ -60,7 +65,8 @@ public interface User extends Snowflake {
      * @return String containing a URL to their effective avatar, options considered. Never null.
      */
     @Nonnull
-    String effectiveAvatarUrl(final ImageOptions options);
+    @CheckReturnValue
+    String effectiveAvatarUrl(@Nonnull final ImageOptions options);
     
     /**
      * The URL for the user's effective avatar, as displayed in the Discord client.
@@ -70,6 +76,7 @@ public interface User extends Snowflake {
      * @return String containing a URL to their effective avatar. Never null.
      */
     @Nonnull
+    @CheckReturnValue
     String effectiveAvatarUrl();
     
     /**
@@ -78,6 +85,7 @@ public interface User extends Snowflake {
      * @return User's name. Never null.
      */
     @Nonnull
+    @CheckReturnValue
     String username();
     
     /**
@@ -86,6 +94,7 @@ public interface User extends Snowflake {
      * @return User's ID. never null.
      */
     @Nonnull
+    @CheckReturnValue
     String id();
     
     /**
@@ -94,6 +103,7 @@ public interface User extends Snowflake {
      * @return 4 digit discriminator as a string. Never null.
      */
     @Nonnull
+    @CheckReturnValue
     String discriminator();
     
     /**
@@ -105,6 +115,7 @@ public interface User extends Snowflake {
      * @return User's hashed avatar string. Can be null.
      */
     @Nullable
+    @CheckReturnValue
     String avatar();
     
     /**
@@ -112,5 +123,15 @@ public interface User extends Snowflake {
      *
      * @return True if the user is a bot, false if the user is a human.
      */
+    @CheckReturnValue
     boolean bot();
+    
+    /**
+     * Creates a DM channel with this user.
+     *
+     * @return Future with the result of the DM creation.
+     */
+    default CompletableFuture<DMChannel> createDM() {
+        return catnip().rest().channel().createDM(id());
+    }
 }

--- a/src/main/java/com/mewna/catnip/entity/User.java
+++ b/src/main/java/com/mewna/catnip/entity/User.java
@@ -18,7 +18,7 @@ public interface User extends Snowflake {
      * @return True if the avatar is animated, false otherwise.
      */
     @CheckReturnValue
-    boolean isAvatarAnimated();
+    boolean animatedAvatar();
     
     /**
      * The URL for the default avatar for this user.

--- a/src/main/java/com/mewna/catnip/entity/User.java
+++ b/src/main/java/com/mewna/catnip/entity/User.java
@@ -132,6 +132,6 @@ public interface User extends Snowflake {
      * @return Future with the result of the DM creation.
      */
     default CompletableFuture<DMChannel> createDM() {
-        return catnip().rest().channel().createDM(id());
+        return catnip().rest().user().createDM(id());
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/User.java
+++ b/src/main/java/com/mewna/catnip/entity/User.java
@@ -9,7 +9,7 @@ import javax.annotation.Nullable;
  * @author amy
  * @since 9/4/18
  */
-public interface User {
+public interface User extends Snowflake {
     
     /**
      * Whether the user's avatar is animated.

--- a/src/main/java/com/mewna/catnip/entity/UserDMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/UserDMChannel.java
@@ -1,18 +1,25 @@
 package com.mewna.catnip.entity;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 /**
  * @author natanbc
  * @since 9/12/18
  */
 public interface UserDMChannel extends DMChannel {
+    @Nonnull
+    @CheckReturnValue
     User recipient();
     
     @Override
+    @CheckReturnValue
     default boolean isUserDM() {
         return true;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isGroupDM() {
         return false;
     }

--- a/src/main/java/com/mewna/catnip/entity/UserDMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/UserDMChannel.java
@@ -1,5 +1,9 @@
 package com.mewna.catnip.entity;
 
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
 public interface UserDMChannel extends DMChannel {
     User recipient();
     

--- a/src/main/java/com/mewna/catnip/entity/UserDMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/UserDMChannel.java
@@ -1,0 +1,15 @@
+package com.mewna.catnip.entity;
+
+public interface UserDMChannel extends DMChannel {
+    User recipient();
+    
+    @Override
+    default boolean isUserDM() {
+        return true;
+    }
+    
+    @Override
+    default boolean isGroupDM() {
+        return false;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/VoiceChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/VoiceChannel.java
@@ -1,24 +1,32 @@
 package com.mewna.catnip.entity;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * @author natanbc
  * @since 9/12/18
  */
 public interface VoiceChannel extends GuildChannel {
+    @CheckReturnValue
     int bitrate();
+    
+    @CheckReturnValue
     int userLimit();
     
     @Override
+    @CheckReturnValue
     default boolean isText() {
         return false;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isVoice() {
         return true;
     }
     
     @Override
+    @CheckReturnValue
     default boolean isCategory() {
         return false;
     }

--- a/src/main/java/com/mewna/catnip/entity/VoiceChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/VoiceChannel.java
@@ -1,0 +1,25 @@
+package com.mewna.catnip.entity;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+public interface VoiceChannel extends GuildChannel {
+    int bitrate();
+    int userLimit();
+    
+    @Override
+    default boolean isText() {
+        return false;
+    }
+    
+    @Override
+    default boolean isVoice() {
+        return true;
+    }
+    
+    @Override
+    default boolean isCategory() {
+        return false;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/VoiceRegion.java
+++ b/src/main/java/com/mewna/catnip/entity/VoiceRegion.java
@@ -1,19 +1,30 @@
 package com.mewna.catnip.entity;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 /**
  * @author natanbc
  * @since 9/14/18
  */
 public interface VoiceRegion extends Entity {
+    @Nonnull
+    @CheckReturnValue
     String id();
     
+    @Nonnull
+    @CheckReturnValue
     String name();
     
+    @CheckReturnValue
     boolean vip();
     
+    @CheckReturnValue
     boolean optimal();
     
+    @CheckReturnValue
     boolean deprecated();
     
+    @CheckReturnValue
     boolean custom();
 }

--- a/src/main/java/com/mewna/catnip/entity/VoiceRegion.java
+++ b/src/main/java/com/mewna/catnip/entity/VoiceRegion.java
@@ -1,0 +1,19 @@
+package com.mewna.catnip.entity;
+
+/**
+ * @author natanbc
+ * @since 9/14/18
+ */
+public interface VoiceRegion extends Entity {
+    String id();
+    
+    String name();
+    
+    boolean vip();
+    
+    boolean optimal();
+    
+    boolean deprecated();
+    
+    boolean custom();
+}

--- a/src/main/java/com/mewna/catnip/entity/Webhook.java
+++ b/src/main/java/com/mewna/catnip/entity/Webhook.java
@@ -1,0 +1,50 @@
+package com.mewna.catnip.entity;
+
+import com.mewna.catnip.rest.RestRequester;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author natanbc
+ * @since 9/15/18
+ */
+public interface Webhook extends Snowflake {
+    @Nonnull
+    @CheckReturnValue
+    String guildId();
+    
+    @Nonnull
+    @CheckReturnValue
+    String channelId();
+    
+    @Nonnull
+    @CheckReturnValue
+    User user();
+    
+    @Nullable
+    @CheckReturnValue
+    String name();
+    
+    @Nullable
+    @CheckReturnValue
+    String avatar();
+    
+    @Nonnull
+    @CheckReturnValue
+    String token();
+    
+    @Nonnull
+    @CheckReturnValue
+    default String url() {
+        return String.format("%s/webhooks/%s/%s", RestRequester.API_BASE, id(), token());
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    default CompletableFuture<Void> delete() {
+        return catnip().rest().webhook().deleteWebhook(id());
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/Webhook.java
+++ b/src/main/java/com/mewna/catnip/entity/Webhook.java
@@ -1,10 +1,15 @@
 package com.mewna.catnip.entity;
 
 import com.mewna.catnip.rest.RestRequester;
+import io.vertx.core.json.JsonObject;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -46,5 +51,47 @@ public interface Webhook extends Snowflake {
     @CheckReturnValue
     default CompletableFuture<Void> delete() {
         return catnip().rest().webhook().deleteWebhook(id());
+    }
+    
+    @Getter
+    @Setter
+    @Accessors(fluent = true)
+    class WebhookEditFields {
+        private final Webhook webhook;
+        private String name;
+        private String avatar;
+        private String channelId;
+        
+        public WebhookEditFields(@Nullable final Webhook webhook) {
+            this.webhook = webhook;
+        }
+    
+        public WebhookEditFields() {
+            this(null);
+        }
+    
+        @Nonnull
+        public CompletableFuture<Webhook> submit() {
+            if(webhook == null) {
+                throw new IllegalStateException("Cannot submit edit without a webhook object! Please use RestWebhook directly instead");
+            }
+            return webhook.catnip().rest().webhook().modifyWebhook(webhook.id(), this);
+        }
+    
+        @Nonnull
+        @CheckReturnValue
+        public JsonObject payload() {
+            final JsonObject payload = new JsonObject();
+            if(name != null && (webhook == null || !Objects.equals(name, webhook.name()))) {
+                payload.put("name", name);
+            }
+            if(avatar != null && (webhook == null || !Objects.equals(avatar, webhook.avatar()))) {
+                payload.put("avatar", avatar);
+            }
+            if(channelId != null && (webhook == null || !Objects.equals(channelId, webhook.channelId()))) {
+                payload.put("channel_id", channelId);
+            }
+            return payload;
+        }
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/impl/CategoryImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/CategoryImpl.java
@@ -1,0 +1,49 @@
+package com.mewna.catnip.entity.impl;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.Category;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+@Getter
+@Setter
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryImpl implements Category, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private String id;
+    private ChannelType type;
+    private String name;
+    private String guildId;
+    private int position;
+    private String parentId;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
+    
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof Category && ((Category)obj).id().equals(id);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("Category (%s)", name);
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/impl/CategoryImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/CategoryImpl.java
@@ -2,10 +2,12 @@ package com.mewna.catnip.entity.impl;
 
 import com.mewna.catnip.Catnip;
 import com.mewna.catnip.entity.Category;
+import com.mewna.catnip.entity.PermissionOverride;
 import lombok.*;
 import lombok.experimental.Accessors;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * @author natanbc
@@ -26,6 +28,7 @@ public class CategoryImpl implements Category, RequiresCatnip {
     private String guildId;
     private int position;
     private String parentId;
+    private List<PermissionOverride> overrides;
     
     @Override
     public void catnip(@Nonnull final Catnip catnip) {

--- a/src/main/java/com/mewna/catnip/entity/impl/CreatedInviteImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/CreatedInviteImpl.java
@@ -1,0 +1,41 @@
+package com.mewna.catnip.entity.impl;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.CreatedInvite;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+import java.time.OffsetDateTime;
+
+/**
+ * @author natanbc
+ * @since 9/14/18.
+ */
+@Getter
+@Setter
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreatedInviteImpl implements CreatedInvite, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private String code;
+    private Inviter inviter;
+    private InviteGuild guild;
+    private InviteChannel channel;
+    private int approximatePresenceCount;
+    private int approximateMemberCount;
+    private int uses;
+    private int maxUses;
+    private int maxAge;
+    private boolean temporary;
+    private OffsetDateTime createdAt;
+    private boolean revoked;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -472,12 +472,6 @@ public final class EntityBuilder {
     
     @Nonnull
     @CheckReturnValue
-    public List<Message> createManyMessages(@Nonnull final JsonArray data) {
-        return data.stream().map(e -> (JsonObject) e).map(this::createMessage).collect(Collectors.toList());
-    }
-    
-    @Nonnull
-    @CheckReturnValue
     public Guild createGuild(@Nonnull final JsonObject data) {
         return GuildImpl.builder()
                 .catnip(catnip)

--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -600,4 +600,19 @@ public final class EntityBuilder {
                 .custom(data.getBoolean("custom", false))
                 .build();
     }
+    
+    @Nonnull
+    @CheckReturnValue
+    public Webhook createWebhook(@Nonnull final JsonObject data) {
+        return WebhookImpl.builder()
+                .catnip(catnip)
+                .id(data.getString("id"))
+                .guildId(data.getString("guild_id"))
+                .channelId(data.getString("channel_id"))
+                .user(createUser(data.getJsonObject("user")))
+                .name(data.getString("name"))
+                .avatar(data.getString("avatar"))
+                .token(data.getString("token"))
+                .build();
+    }
 }

--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -12,7 +12,13 @@ import com.mewna.catnip.entity.Guild.ContentFilterLevel;
 import com.mewna.catnip.entity.Guild.MFALevel;
 import com.mewna.catnip.entity.Guild.NotificationLevel;
 import com.mewna.catnip.entity.Guild.VerificationLevel;
+import com.mewna.catnip.entity.Invite.InviteChannel;
+import com.mewna.catnip.entity.Invite.InviteGuild;
+import com.mewna.catnip.entity.Invite.Inviter;
 import com.mewna.catnip.entity.impl.EmbedImpl.*;
+import com.mewna.catnip.entity.impl.InviteImpl.InviteChannelImpl;
+import com.mewna.catnip.entity.impl.InviteImpl.InviteGuildImpl;
+import com.mewna.catnip.entity.impl.InviteImpl.InviterImpl;
 import com.mewna.catnip.entity.impl.MessageImpl.Attachment;
 import com.mewna.catnip.entity.impl.MessageImpl.Reaction;
 import io.vertx.core.json.JsonArray;
@@ -504,6 +510,80 @@ public final class EntityBuilder {
                 .memberCount(data.getInteger("member_count", -1))
                 .members(ImmutableList.copyOf(mapArrayObjects(data.getJsonArray("members"), this::createMember)))
                 .channels(ImmutableList.copyOf(mapArrayObjects(data.getJsonArray("channels"), this::createChannel)))
+                .build();
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public Invite createInvite(@Nonnull final JsonObject data) {
+        if(data.containsKey("uses")) {
+            return createCreatedInvite(data);
+        }
+        return InviteImpl.builder()
+                .catnip(catnip)
+                .code(data.getString("code"))
+                .inviter(createInviter(data.getJsonObject("inviter")))
+                .guild(createInviteGuild(data.getJsonObject("guild")))
+                .channel(createInviteChannel(data.getJsonObject("channel")))
+                .approximatePresenceCount(data.getInteger("approximate_presence_count", -1))
+                .approximateMemberCount(data.getInteger("approximate_member_count", -1))
+                .build();
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CreatedInvite createCreatedInvite(@Nonnull final JsonObject data) {
+        return CreatedInviteImpl.builder()
+                .catnip(catnip)
+                .code(data.getString("code"))
+                .inviter(createInviter(data.getJsonObject("inviter")))
+                .guild(createInviteGuild(data.getJsonObject("guild")))
+                .channel(createInviteChannel(data.getJsonObject("channel")))
+                .approximatePresenceCount(data.getInteger("approximate_presence_count", -1))
+                .approximateMemberCount(data.getInteger("approximate_member_count", -1))
+                .uses(data.getInteger("uses"))
+                .maxUses(data.getInteger("max_uses"))
+                .maxAge(data.getInteger("max_age"))
+                .temporary(data.getBoolean("temporary", false))
+                .createdAt(parseTimestamp(data.getString("created_at")))
+                .revoked(data.getBoolean("revoked", false))
+                .build();
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public InviteChannel createInviteChannel(@Nonnull final JsonObject data) {
+        return InviteChannelImpl.builder()
+                .catnip(catnip)
+                .id(data.getString("id"))
+                .name(data.getString("name"))
+                .type(ChannelType.byKey(data.getInteger("type")))
+                .build();
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public InviteGuild createInviteGuild(@Nonnull final JsonObject data) {
+        return InviteGuildImpl.builder()
+                .catnip(catnip)
+                .id(data.getString("id"))
+                .name(data.getString("name"))
+                .icon(data.getString("icon"))
+                .splash(data.getString("splash"))
+                .features(ImmutableList.copyOf(stringArrayToCollection(data.getJsonArray("features"))))
+                .verificationLevel(VerificationLevel.byKey(data.getInteger("verification_level", 0)))
+                .build();
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public Inviter createInviter(@Nonnull final JsonObject data) {
+        return InviterImpl.builder()
+                .catnip(catnip)
+                .id(data.getString("id"))
+                .username(data.getString("username"))
+                .discriminator(data.getString("discriminator"))
+                .avatar(data.getString("avatar"))
                 .build();
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -586,4 +586,18 @@ public final class EntityBuilder {
                 .avatar(data.getString("avatar"))
                 .build();
     }
+    
+    @Nonnull
+    @CheckReturnValue
+    public VoiceRegion createVoiceRegion(@Nonnull final JsonObject data) {
+        return VoiceRegionImpl.builder()
+                .catnip(catnip)
+                .id(data.getString("id"))
+                .name(data.getString("name"))
+                .vip(data.getBoolean("vip", false))
+                .optimal(data.getBoolean("optimal", false))
+                .deprecated(data.getBoolean("deprecated", false))
+                .custom(data.getBoolean("custom", false))
+                .build();
+    }
 }

--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -15,12 +15,14 @@ import com.mewna.catnip.entity.Guild.VerificationLevel;
 import com.mewna.catnip.entity.Invite.InviteChannel;
 import com.mewna.catnip.entity.Invite.InviteGuild;
 import com.mewna.catnip.entity.Invite.Inviter;
+import com.mewna.catnip.entity.PermissionOverride.OverrideType;
 import com.mewna.catnip.entity.impl.EmbedImpl.*;
 import com.mewna.catnip.entity.impl.InviteImpl.InviteChannelImpl;
 import com.mewna.catnip.entity.impl.InviteImpl.InviteGuildImpl;
 import com.mewna.catnip.entity.impl.InviteImpl.InviterImpl;
 import com.mewna.catnip.entity.impl.MessageImpl.Attachment;
 import com.mewna.catnip.entity.impl.MessageImpl.Reaction;
+import com.mewna.catnip.entity.util.Permission;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -57,7 +59,7 @@ public final class EntityBuilder {
     
     @Nonnull
     @CheckReturnValue
-    private static <T> Collection<T> mapArrayObjects(@Nullable final JsonArray array, @Nonnull final Function<JsonObject, T> mapper) {
+    private static <T> List<T> immutableListOf(@Nullable final JsonArray array, @Nonnull final Function<JsonObject, T> mapper) {
         if(array == null) {
             return Collections.emptyList();
         }
@@ -69,12 +71,12 @@ public final class EntityBuilder {
             }
             ret.add(mapper.apply((JsonObject) object));
         }
-        return ret;
+        return ImmutableList.copyOf(ret);
     }
     
     @Nonnull
     @CheckReturnValue
-    private static Collection<String> stringArrayToCollection(@Nullable final JsonArray array) {
+    private static List<String> stringListOf(@Nullable final JsonArray array) {
         if(array == null) {
             return Collections.emptyList();
         }
@@ -86,7 +88,7 @@ public final class EntityBuilder {
             }
             ret.add((String) object);
         }
-        return ret;
+        return ImmutableList.copyOf(ret);
     }
     
     @Nullable
@@ -218,8 +220,6 @@ public final class EntityBuilder {
                 .proxyIconUrl(authorRaw.getString("proxy_icon_url"))
                 .build();
         
-        final Collection<Field> fields = mapArrayObjects(data.getJsonArray("fields"), this::createField);
-        
         return EmbedImpl.builder()
                 .title(data.getString("title"))
                 .type(EmbedType.byKey(data.getString("type")))
@@ -233,7 +233,7 @@ public final class EntityBuilder {
                 .video(video)
                 .provider(provider)
                 .author(author)
-                .fields(ImmutableList.copyOf(fields))
+                .fields(immutableListOf(data.getJsonArray("fields"), this::createField))
                 .build();
     }
     
@@ -248,6 +248,7 @@ public final class EntityBuilder {
                 .guildId(data.getString("guild_id"))
                 .position(data.getInteger("position", -1))
                 .parentId(data.getString("parent_id"))
+                .overrides(immutableListOf(data.getJsonArray("permission_overwrites"), this::createPermissionOverride))
                 .topic(data.getString("topic"))
                 .nsfw(data.getBoolean("nsfw", false))
                 .build();
@@ -264,6 +265,7 @@ public final class EntityBuilder {
                 .guildId(data.getString("guild_id"))
                 .position(data.getInteger("position", -1))
                 .parentId(data.getString("parent_id"))
+                .overrides(immutableListOf(data.getJsonArray("permission_overwrites"), this::createPermissionOverride))
                 .bitrate(data.getInteger("bitrate", 0))
                 .userLimit(data.getInteger("user_limit", 0))
                 .build();
@@ -280,6 +282,7 @@ public final class EntityBuilder {
                 .guildId(data.getString("guild_id"))
                 .position(data.getInteger("position", -1))
                 .parentId(data.getString("parent_id"))
+                .overrides(immutableListOf(data.getJsonArray("permission_overwrites"), this::createPermissionOverride))
                 .build();
     }
     
@@ -301,7 +304,7 @@ public final class EntityBuilder {
                 .catnip(catnip)
                 .id(data.getString("id"))
                 .type(ChannelType.VOICE)
-                .recipients(ImmutableList.copyOf(mapArrayObjects(data.getJsonArray("recipients"), this::createUser)))
+                .recipients(immutableListOf(data.getJsonArray("recipients"), this::createUser))
                 .icon(data.getString("icon"))
                 .ownerId(data.getString("owner_id"))
                 .applicationId(data.getString("application_id"))
@@ -310,16 +313,48 @@ public final class EntityBuilder {
     
     @Nonnull
     @CheckReturnValue
-    public Channel createChannel(@Nonnull final JsonObject data) {
-        ChannelType type = ChannelType.byKey(data.getInteger("type"));
+    public GuildChannel createGuildChannel(@Nonnull final JsonObject data) {
+        final ChannelType type = ChannelType.byKey(data.getInteger("type"));
         switch(type) {
             case TEXT: return createTextChannel(data);
-            case DM: return createUserDM(data);
             case VOICE: return createVoiceChannel(data);
-            case GROUP_DM: return createGroupDM(data);
             case CATEGORY: return createCategory(data);
             default: throw new UnsupportedOperationException("Unsupported channel type " + type);
         }
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public DMChannel createDMChannel(@Nonnull final JsonObject data) {
+        final ChannelType type = ChannelType.byKey(data.getInteger("type"));
+        switch(type) {
+            case DM: return createUserDM(data);
+            case GROUP_DM: return createGroupDM(data);
+            default: throw new UnsupportedOperationException("Unsupported channel type " + type);
+        }
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public Channel createChannel(@Nonnull final JsonObject data) {
+        final ChannelType type = ChannelType.byKey(data.getInteger("type"));
+        if(type.isGuild()) {
+            return createGuildChannel(data);
+        } else {
+            return createDMChannel(data);
+        }
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public PermissionOverride createPermissionOverride(@Nonnull final JsonObject data) {
+        return PermissionOverrideImpl.builder()
+                .catnip(catnip)
+                .id(data.getString("id"))
+                .type(OverrideType.byKey(data.getString("type")))
+                .allow(Permission.toSet(data.getLong("allow", 0L)))
+                .deny(Permission.toSet(data.getLong("deny", 0L)))
+                .build();
     }
     
     @Nonnull
@@ -390,14 +425,13 @@ public final class EntityBuilder {
     @Nonnull
     @CheckReturnValue
     public CustomEmoji createCustomEmoji(@Nonnull final JsonObject data) {
-        final Collection<String> roles = stringArrayToCollection(data.getJsonArray("roles"));
         final JsonObject userRaw = data.getJsonObject("user");
         
         return CustomEmojiImpl.builder()
                 .catnip(catnip)
                 .id(data.getString("id"))
                 .name(data.getString("name"))
-                .roles(ImmutableList.copyOf(roles))
+                .roles(stringListOf(data.getJsonArray("roles")))
                 .user(userRaw == null ? null : createUser(userRaw))
                 .requiresColons(data.getBoolean("require_colons", true))
                 .managed(data.getBoolean("managed", false))
@@ -444,12 +478,6 @@ public final class EntityBuilder {
         final JsonObject memberRaw = data.getJsonObject("member");
         final Member member = memberRaw == null ? null : createMember(author, memberRaw);
         
-        final Collection<User> mentionedUsers = mapArrayObjects(data.getJsonArray("mentions"), this::createUser);
-        final Collection<Embed> embeds = mapArrayObjects(data.getJsonArray("embeds"), this::createEmbed);
-        final Collection<String> mentionedRoles = stringArrayToCollection(data.getJsonArray("mention_roles"));
-        final Collection<Message.Attachment> attachments = mapArrayObjects(data.getJsonArray("attachments"), this::createAttachment);
-        final Collection<Message.Reaction> reactions = mapArrayObjects(data.getJsonArray("reactions"), this::createReaction);
-        
         return MessageImpl.builder()
                 .catnip(catnip)
                 .id(data.getString("id"))
@@ -460,11 +488,11 @@ public final class EntityBuilder {
                 .editedTimestamp(parseTimestamp(data.getString("edited_timestamp")))
                 .tts(data.getBoolean("tts"))
                 .mentionsEveryone(data.getBoolean("mention_everyone", false))
-                .mentionedUsers(ImmutableList.copyOf(mentionedUsers))
-                .mentionedRoles(ImmutableList.copyOf(mentionedRoles))
-                .attachments(ImmutableList.copyOf(attachments))
-                .embeds(ImmutableList.copyOf(embeds))
-                .reactions(ImmutableList.copyOf(reactions))
+                .mentionedUsers(immutableListOf(data.getJsonArray("mentions"), this::createUser))
+                .mentionedRoles(stringListOf(data.getJsonArray("mention_roles")))
+                .attachments(immutableListOf(data.getJsonArray("attachments"), this::createAttachment))
+                .embeds(immutableListOf(data.getJsonArray("embeds"), this::createEmbed))
+                .reactions(immutableListOf(data.getJsonArray("reactions"), this::createReaction))
                 .nonce(data.getString("nonce"))
                 .pinned(data.getBoolean("pinned"))
                 .webhookId(data.getString("webhook_id"))
@@ -496,9 +524,9 @@ public final class EntityBuilder {
                 .verificationLevel(VerificationLevel.byKey(data.getInteger("verification_level", 0)))
                 .defaultMessageNotifications(NotificationLevel.byKey(data.getInteger("default_message_notifications", 0)))
                 .explicitContentFilter(ContentFilterLevel.byKey(data.getInteger("explicit_content_filter", 0)))
-                .roles(ImmutableList.copyOf(mapArrayObjects(data.getJsonArray("roles"), this::createRole)))
-                .emojis(ImmutableList.copyOf(mapArrayObjects(data.getJsonArray("emojis"), this::createCustomEmoji)))
-                .features(ImmutableList.copyOf(stringArrayToCollection(data.getJsonArray("features"))))
+                .roles(immutableListOf(data.getJsonArray("roles"), this::createRole))
+                .emojis(immutableListOf(data.getJsonArray("emojis"), this::createCustomEmoji))
+                .features(stringListOf(data.getJsonArray("features")))
                 .mfaLevel(MFALevel.byKey(data.getInteger("mfa_level", 0)))
                 .applicationId(data.getString("application_id"))
                 .widgetEnabled(data.getBoolean("widget_enabled", false))
@@ -508,8 +536,8 @@ public final class EntityBuilder {
                 .large(data.getBoolean("large", false))
                 .unavailable(data.getBoolean("unavailable", false))
                 .memberCount(data.getInteger("member_count", -1))
-                .members(ImmutableList.copyOf(mapArrayObjects(data.getJsonArray("members"), this::createMember)))
-                .channels(ImmutableList.copyOf(mapArrayObjects(data.getJsonArray("channels"), this::createChannel)))
+                .members(immutableListOf(data.getJsonArray("members"), this::createMember))
+                .channels(immutableListOf(data.getJsonArray("channels"), this::createChannel))
                 .build();
     }
     
@@ -570,7 +598,7 @@ public final class EntityBuilder {
                 .name(data.getString("name"))
                 .icon(data.getString("icon"))
                 .splash(data.getString("splash"))
-                .features(ImmutableList.copyOf(stringArrayToCollection(data.getJsonArray("features"))))
+                .features(stringListOf(data.getJsonArray("features")))
                 .verificationLevel(VerificationLevel.byKey(data.getInteger("verification_level", 0)))
                 .build();
     }

--- a/src/main/java/com/mewna/catnip/entity/impl/GroupDMChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/GroupDMChannelImpl.java
@@ -1,0 +1,51 @@
+package com.mewna.catnip.entity.impl;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.GroupDMChannel;
+import com.mewna.catnip.entity.User;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+@Getter
+@Setter
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupDMChannelImpl implements GroupDMChannel, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private String id;
+    private ChannelType type;
+    private List<User> recipients;
+    private String icon;
+    private String ownerId;
+    private String applicationId;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
+    
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof GroupDMChannel && ((GroupDMChannel)obj).id().equals(id);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("GroupDMChannel (%s)", recipients);
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/impl/GuildImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/GuildImpl.java
@@ -7,7 +7,7 @@ import com.mewna.catnip.entity.Guild;
 import com.mewna.catnip.entity.Member;
 import com.mewna.catnip.entity.Role;
 import com.mewna.catnip.entity.util.ImageOptions;
-import com.mewna.catnip.entity.util.ImageType;
+import com.mewna.catnip.entity.util.Permission;
 import com.mewna.catnip.util.CDNFormat;
 import lombok.*;
 import lombok.experimental.Accessors;

--- a/src/main/java/com/mewna/catnip/entity/impl/GuildImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/GuildImpl.java
@@ -8,6 +8,7 @@ import com.mewna.catnip.entity.Member;
 import com.mewna.catnip.entity.Role;
 import com.mewna.catnip.entity.util.ImageOptions;
 import com.mewna.catnip.entity.util.ImageType;
+import com.mewna.catnip.util.CDNFormat;
 import lombok.*;
 import lombok.experimental.Accessors;
 
@@ -70,29 +71,13 @@ public class GuildImpl implements Guild, RequiresCatnip {
     @Nullable
     @CheckReturnValue
     public String iconUrl(@Nonnull final ImageOptions options) {
-        if(icon == null) {
-            return null;
-        }
-        if(options.getType() == ImageType.GIF) {
-            throw new IllegalArgumentException("Guild icons may not be GIFs");
-        }
-        return options.buildUrl(
-                String.format("https://cdn.discordapp.com/icons/%s/%s", id, icon)
-        );
+        return CDNFormat.iconUrl(id, icon, options);
     }
     
     @Override
     @Nullable
     @CheckReturnValue
     public String splashUrl(@Nonnull final ImageOptions options) {
-        if(splash == null) {
-            return null;
-        }
-        if(options.getType() == ImageType.GIF) {
-            throw new IllegalArgumentException("Guild icons may not be GIFs");
-        }
-        return options.buildUrl(
-                String.format("https://cdn.discordapp.com/splashes/%s/%s", id, splash)
-        );
+        return CDNFormat.splashUrl(id, splash, options);
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/impl/GuildImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/GuildImpl.java
@@ -1,6 +1,7 @@
 package com.mewna.catnip.entity.impl;
 
 import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.Channel;
 import com.mewna.catnip.entity.Emoji.CustomEmoji;
 import com.mewna.catnip.entity.Guild;
 import com.mewna.catnip.entity.Member;
@@ -58,6 +59,7 @@ public class GuildImpl implements Guild, RequiresCatnip {
     private boolean unavailable;
     private int memberCount;
     private List<Member> members;
+    private List<Channel> channels;
     
     @Override
     public void catnip(@Nonnull final Catnip catnip) {

--- a/src/main/java/com/mewna/catnip/entity/impl/InviteImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/InviteImpl.java
@@ -1,0 +1,217 @@
+package com.mewna.catnip.entity.impl;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.Channel.ChannelType;
+import com.mewna.catnip.entity.Guild.VerificationLevel;
+import com.mewna.catnip.entity.Invite;
+import com.mewna.catnip.entity.util.ImageOptions;
+import com.mewna.catnip.entity.util.ImageType;
+import com.mewna.catnip.util.CDNFormat;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author natanbc
+ * @since 9/14/18.
+ */
+@Getter
+@Setter
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class InviteImpl implements Invite, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private String code;
+    private Inviter inviter;
+    private InviteGuild guild;
+    private InviteChannel channel;
+    private int approximatePresenceCount;
+    private int approximateMemberCount;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
+    
+    @Override
+    public int hashCode() {
+        return code.hashCode();
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof Invite && ((Invite)obj).code().equals(code);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("Invite (%s)", code);
+    }
+    
+    @Getter
+    @Setter
+    @Builder
+    @Accessors(fluent = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InviterImpl implements Inviter, RequiresCatnip {
+        private transient Catnip catnip;
+        
+        private String id;
+        private String username;
+        private String discriminator;
+        private String avatar;
+    
+        @Override
+        public void catnip(@Nonnull final Catnip catnip) {
+            this.catnip = catnip;
+        }
+    
+        @Override
+        public boolean animatedAvatar() {
+            return avatar != null && avatar.startsWith("a_");
+        }
+    
+        @Nonnull
+        @Override
+        public String defaultAvatarUrl() {
+            return CDNFormat.defaultAvatarUrl(discriminator);
+        }
+    
+        @Nullable
+        @Override
+        public String avatarUrl(@Nonnull final ImageOptions options) {
+            return CDNFormat.avatarUrl(id, avatar, options);
+        }
+    
+        @Nullable
+        @Override
+        public String avatarUrl() {
+            return avatarUrl(defaultOptions());
+        }
+    
+        @Nonnull
+        @Override
+        public String effectiveAvatarUrl(@Nonnull final ImageOptions options) {
+            return avatar == null ? defaultAvatarUrl() : Objects.requireNonNull(
+                    avatarUrl(options),
+                    "Avatar url is null but avatar hash is present (??)"
+            );
+        }
+    
+        @Nonnull
+        @Override
+        public String effectiveAvatarUrl() {
+            return effectiveAvatarUrl(defaultOptions());
+        }
+    
+        private ImageOptions defaultOptions() {
+            return new ImageOptions().type(animatedAvatar() ? ImageType.GIF : null);
+        }
+    
+        @Override
+        public int hashCode() {
+            return id.hashCode();
+        }
+    
+        @Override
+        public boolean equals(final Object obj) {
+            return obj instanceof Inviter && ((Inviter)obj).id().equals(id);
+        }
+    
+        @Override
+        public String toString() {
+            return String.format("Inviter (%s)", username);
+        }
+    }
+    
+    @Getter
+    @Setter
+    @Builder
+    @Accessors(fluent = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InviteGuildImpl implements InviteGuild, RequiresCatnip {
+        private transient Catnip catnip;
+        
+        private String id;
+        private String name;
+        private String icon;
+        private String splash;
+        private List<String> features;
+        private VerificationLevel verificationLevel;
+    
+        @Override
+        public void catnip(@Nonnull final Catnip catnip) {
+            this.catnip = catnip;
+        }
+        
+        @Nullable
+        @Override
+        public String iconUrl(@Nonnull final ImageOptions options) {
+            return CDNFormat.iconUrl(id, icon, options);
+        }
+    
+        @Nullable
+        @Override
+        public String splashUrl(@Nonnull final ImageOptions options) {
+            return CDNFormat.splashUrl(id, splash, options);
+        }
+    
+        @Override
+        public int hashCode() {
+            return id.hashCode();
+        }
+    
+        @Override
+        public boolean equals(final Object obj) {
+            return obj instanceof InviteGuild && ((InviteGuild)obj).id().equals(id);
+        }
+    
+        @Override
+        public String toString() {
+            return String.format("InviteGuild (%s)", name);
+        }
+    }
+    
+    @Getter
+    @Setter
+    @Builder
+    @Accessors(fluent = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InviteChannelImpl implements InviteChannel, RequiresCatnip {
+        private transient Catnip catnip;
+        
+        private String id;
+        private String name;
+        private ChannelType type;
+        
+        @Override
+        public void catnip(@Nonnull final Catnip catnip) {
+            this.catnip = catnip;
+        }
+        
+        @Override
+        public int hashCode() {
+            return id.hashCode();
+        }
+        
+        @Override
+        public boolean equals(final Object obj) {
+            return obj instanceof InviteChannel && ((InviteChannel)obj).id().equals(id);
+        }
+        
+        @Override
+        public String toString() {
+            return String.format("InviteChannel (%s)", name);
+        }
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/impl/PermissionOverrideImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/PermissionOverrideImpl.java
@@ -1,7 +1,7 @@
 package com.mewna.catnip.entity.impl;
 
 import com.mewna.catnip.Catnip;
-import com.mewna.catnip.entity.Role;
+import com.mewna.catnip.entity.PermissionOverride;
 import com.mewna.catnip.entity.util.Permission;
 import lombok.*;
 import lombok.experimental.Accessors;
@@ -10,8 +10,8 @@ import javax.annotation.Nonnull;
 import java.util.Set;
 
 /**
- * @author Julia Rogers
- * @since 9/2/18
+ * @author natanbc
+ * @since 9/15/18
  */
 @Getter
 @Setter
@@ -19,17 +19,13 @@ import java.util.Set;
 @Accessors(fluent = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class RoleImpl implements Role, RequiresCatnip {
+public class PermissionOverrideImpl implements PermissionOverride, RequiresCatnip {
     private transient Catnip catnip;
     
     private String id;
-    private String name;
-    private int color;
-    private boolean hoist;
-    private int position;
-    private Set<Permission> permissions;
-    private boolean managed;
-    private boolean mentionable;
+    private OverrideType type;
+    private Set<Permission> allow;
+    private Set<Permission> deny;
     
     @Override
     public void catnip(@Nonnull final Catnip catnip) {
@@ -43,11 +39,11 @@ public class RoleImpl implements Role, RequiresCatnip {
     
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof Role && ((Role)obj).id().equals(id);
+        return obj instanceof PermissionOverride && ((PermissionOverride)obj).id().equals(id);
     }
     
     @Override
     public String toString() {
-        return String.format("Role (%s)", name);
+        return String.format("PermissionOverride (%s)", id);
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/impl/TextChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/TextChannelImpl.java
@@ -1,0 +1,51 @@
+package com.mewna.catnip.entity.impl;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.TextChannel;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+@Getter
+@Setter
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class TextChannelImpl implements TextChannel, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private String id;
+    private ChannelType type;
+    private String name;
+    private String guildId;
+    private int position;
+    private String parentId;
+    private String topic;
+    private boolean nsfw;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
+    
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof TextChannel && ((TextChannel)obj).id().equals(id);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("TextChannel (%s)", name);
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/impl/TextChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/TextChannelImpl.java
@@ -1,11 +1,13 @@
 package com.mewna.catnip.entity.impl;
 
 import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.PermissionOverride;
 import com.mewna.catnip.entity.TextChannel;
 import lombok.*;
 import lombok.experimental.Accessors;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * @author natanbc
@@ -26,6 +28,7 @@ public class TextChannelImpl implements TextChannel, RequiresCatnip {
     private String guildId;
     private int position;
     private String parentId;
+    private List<PermissionOverride> overrides;
     private String topic;
     private boolean nsfw;
     

--- a/src/main/java/com/mewna/catnip/entity/impl/UserDMChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/UserDMChannelImpl.java
@@ -1,0 +1,47 @@
+package com.mewna.catnip.entity.impl;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.User;
+import com.mewna.catnip.entity.UserDMChannel;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+@Getter
+@Setter
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDMChannelImpl implements UserDMChannel, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private String id;
+    private ChannelType type;
+    private User recipient;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
+    
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof UserDMChannel && ((UserDMChannel)obj).id().equals(id);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("UserDMChannel (%s)", recipient);
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/impl/UserImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/UserImpl.java
@@ -4,6 +4,7 @@ import com.mewna.catnip.Catnip;
 import com.mewna.catnip.entity.User;
 import com.mewna.catnip.entity.util.ImageOptions;
 import com.mewna.catnip.entity.util.ImageType;
+import com.mewna.catnip.util.CDNFormat;
 import lombok.*;
 import lombok.experimental.Accessors;
 
@@ -33,30 +34,22 @@ public class UserImpl implements User, RequiresCatnip {
     private String avatar;
     private boolean bot;
     
+    @Override
     @CheckReturnValue
-    public boolean isAvatarAnimated() {
+    public boolean animatedAvatar() {
         return avatar != null && avatar.startsWith("a_");
     }
     
     @Nonnull
     @CheckReturnValue
     public String defaultAvatarUrl() {
-        final int avatarId = Short.parseShort(discriminator) % 5;
-        return String.format("https://cdn.discordapp.com/embed/avatars/%s.png", avatarId);
+        return CDNFormat.defaultAvatarUrl(discriminator);
     }
     
     @Nullable
     @CheckReturnValue
     public String avatarUrl(@Nonnull final ImageOptions options) {
-        if(avatar == null) {
-            return null;
-        }
-        if(options.getType() == ImageType.GIF && !avatar.startsWith("a_")) {
-            throw new IllegalArgumentException("Cannot build gif avatar URL for non gif avatar!");
-        }
-        return options.buildUrl(
-                String.format("https://cdn.discordapp.com/avatars/%s/%s", id, avatar)
-        );
+        return CDNFormat.avatarUrl(id, avatar, options);
     }
     
     @Nullable
@@ -86,7 +79,7 @@ public class UserImpl implements User, RequiresCatnip {
     }
     
     private ImageOptions defaultOptions() {
-        return new ImageOptions().type(isAvatarAnimated() ? ImageType.GIF : null);
+        return new ImageOptions().type(animatedAvatar() ? ImageType.GIF : null);
     }
     
     @Override

--- a/src/main/java/com/mewna/catnip/entity/impl/UserImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/UserImpl.java
@@ -17,7 +17,6 @@ import java.util.Objects;
  * @author amy
  * @since 9/1/18.
  */
-
 @Getter
 @Setter
 @Builder
@@ -33,6 +32,11 @@ public class UserImpl implements User, RequiresCatnip {
     private String discriminator;
     private String avatar;
     private boolean bot;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
     
     @Override
     @CheckReturnValue
@@ -71,11 +75,6 @@ public class UserImpl implements User, RequiresCatnip {
     @CheckReturnValue
     public String effectiveAvatarUrl() {
         return effectiveAvatarUrl(defaultOptions());
-    }
-    
-    @Override
-    public void catnip(@Nonnull final Catnip catnip) {
-        this.catnip = catnip;
     }
     
     private ImageOptions defaultOptions() {

--- a/src/main/java/com/mewna/catnip/entity/impl/VoiceChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/VoiceChannelImpl.java
@@ -1,11 +1,13 @@
 package com.mewna.catnip.entity.impl;
 
 import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.PermissionOverride;
 import com.mewna.catnip.entity.VoiceChannel;
 import lombok.*;
 import lombok.experimental.Accessors;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 /**
  * @author natanbc
@@ -26,6 +28,7 @@ public class VoiceChannelImpl implements VoiceChannel, RequiresCatnip {
     private String guildId;
     private int position;
     private String parentId;
+    private List<PermissionOverride> overrides;
     private int bitrate;
     private int userLimit;
     

--- a/src/main/java/com/mewna/catnip/entity/impl/VoiceChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/VoiceChannelImpl.java
@@ -1,0 +1,51 @@
+package com.mewna.catnip.entity.impl;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.VoiceChannel;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author natanbc
+ * @since 9/12/18
+ */
+@Getter
+@Setter
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoiceChannelImpl implements VoiceChannel, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private String id;
+    private ChannelType type;
+    private String name;
+    private String guildId;
+    private int position;
+    private String parentId;
+    private int bitrate;
+    private int userLimit;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
+    
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof VoiceChannel && ((VoiceChannel)obj).id().equals(id);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("VoiceChannel (%s)", name);
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/impl/VoiceRegionImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/VoiceRegionImpl.java
@@ -1,0 +1,34 @@
+package com.mewna.catnip.entity.impl;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.VoiceRegion;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author natanbc
+ * @since 9/14/18
+ */
+@Getter
+@Setter
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoiceRegionImpl implements VoiceRegion, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private String id;
+    private String name;
+    private boolean vip;
+    private boolean optimal;
+    private boolean deprecated;
+    private boolean custom;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/impl/WebhookImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/WebhookImpl.java
@@ -1,0 +1,51 @@
+package com.mewna.catnip.entity.impl;
+
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.User;
+import com.mewna.catnip.entity.Webhook;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author natanbc
+ * @since 9/15/18
+ */
+@Getter
+@Setter
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebhookImpl implements Webhook, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private String id;
+    private String guildId;
+    private String channelId;
+    private User user;
+    private String name;
+    private String avatar;
+    private String token;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+    }
+    
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof Webhook && ((Webhook)obj).id().equals(id);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("Webhook (%s)", name == null ? id : name);
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/util/Permission.java
+++ b/src/main/java/com/mewna/catnip/entity/util/Permission.java
@@ -1,8 +1,9 @@
-package com.mewna.catnip.entity.impl;
+package com.mewna.catnip.entity.util;
 
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
+import javax.annotation.Nonnull;
 import java.util.*;
 
 /**
@@ -39,7 +40,7 @@ public enum Permission {
     MANAGE_NICKNAME(0x08000000, false),
     MANAGE_ROLES(0x10000000, true),
     MANAGE_WEBHOOKS(0x20000000, true),
-    MEANAGE_EMOJI(0x40000000, false);
+    MANAGE_EMOJI(0x40000000, false);
 
     Permission(final int value, final boolean channel) {
         this.value = value;
@@ -63,5 +64,21 @@ public enum Permission {
         }
 
         return perms;
+    }
+    
+    public static long from(@Nonnull final Iterable<Permission> permissions) {
+        long result = 0;
+        for(final Permission permission : permissions) {
+            result |= permission.value;
+        }
+        return result;
+    }
+    
+    public static long from(@Nonnull final Permission... permissions) {
+        long result = 0;
+        for(final Permission permission : permissions) {
+            result |= permission.value;
+        }
+        return result;
     }
 }

--- a/src/main/java/com/mewna/catnip/internal/CatnipImpl.java
+++ b/src/main/java/com/mewna/catnip/internal/CatnipImpl.java
@@ -43,7 +43,7 @@ public class CatnipImpl implements Catnip {
     private final Vertx vertx;
     // TODO: Allow changing the backend
     @Getter
-    private final RestRequester requester = new RestRequester(this);
+    private final RestRequester requester;
     @Getter
     @Setter
     private String token;
@@ -75,6 +75,7 @@ public class CatnipImpl implements Catnip {
     
     public CatnipImpl(@Nonnull final Vertx vertx) {
         this.vertx = vertx;
+        requester = new RestRequester(this);
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/rest/Rest.java
+++ b/src/main/java/com/mewna/catnip/rest/Rest.java
@@ -24,6 +24,8 @@ public class Rest {
     private final RestInvite invite;
     @Getter
     private final RestVoice voice;
+    @Getter
+    private final RestWebhook webhook;
     
     public Rest(final CatnipImpl catnip) {
         channel = new RestChannel(catnip);
@@ -32,5 +34,6 @@ public class Rest {
         emoji = new RestEmoji(catnip);
         invite = new RestInvite(catnip);
         voice = new RestVoice(catnip);
+        webhook = new RestWebhook(catnip);
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/Rest.java
+++ b/src/main/java/com/mewna/catnip/rest/Rest.java
@@ -22,6 +22,8 @@ public class Rest {
     private final RestEmoji emoji;
     @Getter
     private final RestInvite invite;
+    @Getter
+    private final RestVoice voice;
     
     public Rest(final CatnipImpl catnip) {
         channel = new RestChannel(catnip);
@@ -29,5 +31,6 @@ public class Rest {
         user = new RestUser(catnip);
         emoji = new RestEmoji(catnip);
         invite = new RestInvite(catnip);
+        voice = new RestVoice(catnip);
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/Rest.java
+++ b/src/main/java/com/mewna/catnip/rest/Rest.java
@@ -1,10 +1,7 @@
 package com.mewna.catnip.rest;
 
 import com.mewna.catnip.internal.CatnipImpl;
-import com.mewna.catnip.rest.handler.RestChannel;
-import com.mewna.catnip.rest.handler.RestEmoji;
-import com.mewna.catnip.rest.handler.RestGuild;
-import com.mewna.catnip.rest.handler.RestUser;
+import com.mewna.catnip.rest.handler.*;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
@@ -23,11 +20,14 @@ public class Rest {
     private final RestUser user;
     @Getter
     private final RestEmoji emoji;
+    @Getter
+    private final RestInvite invite;
     
     public Rest(final CatnipImpl catnip) {
         channel = new RestChannel(catnip);
         guild = new RestGuild(catnip);
         user = new RestUser(catnip);
         emoji = new RestEmoji(catnip);
+        invite = new RestInvite(catnip);
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/Routes.java
+++ b/src/main/java/com/mewna/catnip/rest/Routes.java
@@ -150,7 +150,11 @@ public final class Routes {
     public static final Route DELETE_GUILD_ROLE                   = new Route(DELETE, "/guilds/{guild.id}/roles/{role.id}", "guild.id");
     public static final Route MODIFY_GUILD_ROLE                   = new Route(PATCH,  "/guilds/{guild.id}/roles/{role.id}", "guild.id");
     public static final Route GET_GUILD_WEBHOOKS                  = new Route(GET,    "/guilds/{guild.id}/webhooks", "guild.id");
-
+    
+    public static final Route GET_WEBHOOK                         = new Route(GET,    "/webhooks/{webhook.id}");
+    public static final Route MODIFY_WEBHOOK                      = new Route(PATCH,  "/webhooks/{webhook.id}");
+    public static final Route DELETE_WEBHOOK                      = new Route(DELETE, "/webhooks/{webhook.id}");
+    
     public static final Route DELETE_INVITE                       = new Route(DELETE, "/invites/{invite.code}");
     public static final Route GET_INVITE                          = new Route(GET,    "/invites/{invite.code}");
     public static final Route ACCEPT_INVITE                       = new Route(POST,   "/invites/{invite.code}");

--- a/src/main/java/com/mewna/catnip/rest/guild/ChannelData.java
+++ b/src/main/java/com/mewna/catnip/rest/guild/ChannelData.java
@@ -1,0 +1,105 @@
+package com.mewna.catnip.rest.guild;
+
+import com.mewna.catnip.util.JsonConvertible;
+import io.vertx.core.json.JsonObject;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+@Accessors(fluent = true)
+@Getter
+@Setter
+public abstract class ChannelData implements JsonConvertible {
+    private final int type;
+    private final String name;
+    private Integer position;
+    private String topic;
+    private Boolean nsfw;
+    private Integer bitrate;
+    private Integer userLimit;
+    
+    ChannelData(@Nonnegative final int type, @Nonnull final String name) {
+        this.type = type;
+        this.name = name;
+        if(type != 0 && type != 2) {
+            throw new IllegalArgumentException("Type must be either 0 (text) or 2 (voice)");
+        }
+        if(name.length() < 2 || name.length() > 100) {
+            throw new IllegalArgumentException("Name must have 2-100 characters");
+        }
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public static ChannelData createText(@Nonnull final String name) {
+        return new TextChannelData(name.trim());
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public static ChannelData createVoice(@Nonnull final String name) {
+        return new VoiceChannelData(name.trim());
+    }
+    
+    @Override
+    @Nonnull
+    @CheckReturnValue
+    public JsonObject toJson() {
+        final JsonObject object = new JsonObject()
+                .put("name", name)
+                .put("type", type);
+        if(position != null) {
+            object.put("position", position);
+        }
+        if(topic != null) {
+            object.put("topic", topic);
+        }
+        if(nsfw != null) {
+            object.put("nsfw", nsfw);
+        }
+        if(bitrate != null) {
+            object.put("bitrate", bitrate);
+        }
+        if(userLimit != null) {
+            object.put("user_limit", userLimit);
+        }
+        
+        return object;
+    }
+    
+    private static class TextChannelData extends ChannelData {
+        TextChannelData(final String name) {
+            super(0, name);
+        }
+    
+        @Override
+        public ChannelData bitrate(final Integer bitrate) {
+            throw new IllegalStateException("Cannot set bitrate on text channels");
+        }
+    
+        @Override
+        public ChannelData userLimit(final Integer userLimit) {
+            throw new IllegalStateException("Cannot set user limit on text channels");
+        }
+    }
+    
+    private static class VoiceChannelData extends ChannelData {
+        VoiceChannelData(final String name) {
+            super(2, name);
+        }
+    
+        @Override
+        public ChannelData topic(final String topic) {
+            throw new IllegalStateException("Cannot set topic on voice channels");
+        }
+    
+        @Override
+        public Boolean nsfw() {
+            throw new IllegalStateException("Cannot set nsfw on voice channels");
+        }
+    }
+}

--- a/src/main/java/com/mewna/catnip/rest/guild/PartialGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/guild/PartialGuild.java
@@ -1,0 +1,208 @@
+package com.mewna.catnip.rest.guild;
+
+import com.mewna.catnip.entity.Guild.ContentFilterLevel;
+import com.mewna.catnip.entity.Guild.NotificationLevel;
+import com.mewna.catnip.entity.Guild.VerificationLevel;
+import com.mewna.catnip.util.JsonConvertible;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+@Accessors(fluent = true)
+public class PartialGuild implements JsonConvertible {
+    private final List<RoleData> roles = new ArrayList<>();
+    private final List<ChannelData> channels = new ArrayList<>();
+    @Getter
+    /*@Setter already manually generated for length checks*/
+    private String name;
+    @Getter
+    @Setter
+    private String region;
+    @Getter
+    @Setter
+    private String base64Icon;
+    @Getter
+    @Setter
+    private VerificationLevel verificationLevel;
+    @Getter
+    @Setter
+    private NotificationLevel defaultNotificationLevel;
+    @Getter
+    @Setter
+    private ContentFilterLevel explicitContentFilter;
+    
+    public PartialGuild(@Nonnull final String name) {
+        name(name);
+        createRole(); //public role
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public static PartialGuild create(@Nonnull final String name) {
+        return new PartialGuild(name);
+    }
+    
+    @Nonnull
+    public PartialGuild name(final String name) {
+        final String trimmed = name.trim();
+        if(trimmed.length() < 2 || trimmed.length() > 100) {
+            throw new IllegalArgumentException("Name must have 2-100 characters");
+        }
+        this.name = trimmed;
+        return this;
+    }
+    
+    @Nonnull
+    public RoleData createRole() {
+        final RoleData role = RoleData.create(roles.size());
+        roles.add(role);
+        return role;
+    }
+    
+    @Nonnull
+    public PartialGuild createRole(@Nonnull final Consumer<RoleData> configurator) {
+        configurator.accept(createRole());
+        return this;
+    }
+    
+    @Nonnull
+    public RoleData getRole(@Nonnegative final int id) {
+        return roles.get(id);
+    }
+    
+    @Nonnull
+    public PartialGuild configureRole(@Nonnegative final int id, @Nonnull final Consumer<RoleData> configurator) {
+        configurator.accept(getRole(id));
+        return this;
+    }
+    
+    @Nonnull
+    public RoleData getPublicRole() {
+        return getRole(0);
+    }
+    
+    @Nonnull
+    public PartialGuild configurePublicRole(@Nonnull final Consumer<RoleData> configurator) {
+        configurator.accept(getRole(0));
+        return this;
+    }
+    
+    @Nonnull
+    public PartialGuild removeRole(@Nonnull final RoleData role) {
+        if(role.publicRole()) {
+            throw new IllegalArgumentException("Cannot remove public role");
+        }
+        roles.remove(role);
+        return this;
+    }
+    
+    @Nonnull
+    public PartialGuild removeRole(@Nonnegative final int id) {
+        if(id == 0) {
+            throw new IllegalArgumentException("Cannot remove public role");
+        }
+        roles.remove(id);
+        return this;
+    }
+    
+    @Nonnull
+    public PartialGuild addRole(@Nonnull final RoleData role) {
+        roles.add(role);
+        return this;
+    }
+    
+    @Nonnull
+    public ChannelData createTextChannel(@Nonnull final String name) {
+        final ChannelData channel = ChannelData.createText(name);
+        channels.add(channel);
+        return channel;
+    }
+    
+    @Nonnull
+    public PartialGuild createTextChannel(@Nonnull final String name, @Nonnull final Consumer<ChannelData> configurator) {
+        configurator.accept(createTextChannel(name));
+        return this;
+    }
+    
+    @Nonnull
+    public ChannelData createVoiceChannel(@Nonnull final String name) {
+        final ChannelData channel = ChannelData.createVoice(name);
+        channels.add(channel);
+        return channel;
+    }
+    
+    @Nonnull
+    public PartialGuild createVoiceChannel(@Nonnull final String name, @Nonnull final Consumer<ChannelData> configurator) {
+        configurator.accept(createVoiceChannel(name));
+        return this;
+    }
+    
+    @Nonnull
+    public ChannelData getChannel(@Nonnegative final int position) {
+        return channels.get(position);
+    }
+    
+    @Nonnull
+    public PartialGuild removeChannel(@Nonnull final ChannelData channel) {
+        channels.remove(channel);
+        return this;
+    }
+    
+    @Nonnull
+    public PartialGuild removeChannel(@Nonnegative final int position) {
+        channels.remove(position);
+        return this;
+    }
+    
+    @Nonnull
+    public PartialGuild addChannel(@Nonnull final ChannelData channel) {
+        channels.add(channel);
+        return this;
+    }
+    
+    @Override
+    @Nonnull
+    @CheckReturnValue
+    public JsonObject toJson() {
+        final JsonObject object = new JsonObject().put("name", name);
+        if(!channels.isEmpty()) {
+            final JsonArray array = new JsonArray();
+            for(final ChannelData data : channels) {
+                array.add(data.toJson());
+            }
+            object.put("channels", array);
+        }
+        if(!roles.isEmpty()) {
+            final JsonArray array = new JsonArray();
+            for(final RoleData data : roles) {
+                array.add(data.toJson());
+            }
+            object.put("roles", array);
+        }
+        if(region != null) {
+            object.put("region", region);
+        }
+        if(base64Icon != null) {
+            object.put("icon", base64Icon);
+        }
+        if(verificationLevel != null) {
+            object.put("verification_level", verificationLevel.getKey());
+        }
+        if(defaultNotificationLevel != null) {
+            object.put("default_message_notifications", defaultNotificationLevel.getKey());
+        }
+        if(explicitContentFilter != null) {
+            object.put("explicit_content_filter", explicitContentFilter.getKey());
+        }
+        return object;
+    }
+}

--- a/src/main/java/com/mewna/catnip/rest/guild/PermissionOverrideData.java
+++ b/src/main/java/com/mewna/catnip/rest/guild/PermissionOverrideData.java
@@ -1,0 +1,86 @@
+package com.mewna.catnip.rest.guild;
+
+import com.mewna.catnip.entity.Member;
+import com.mewna.catnip.entity.PermissionOverride;
+import com.mewna.catnip.entity.PermissionOverride.OverrideType;
+import com.mewna.catnip.entity.Role;
+import com.mewna.catnip.entity.User;
+import com.mewna.catnip.entity.util.Permission;
+import com.mewna.catnip.util.JsonConvertible;
+import io.vertx.core.json.JsonObject;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+
+public class PermissionOverrideData implements JsonConvertible {
+    private final Set<Permission> allow = EnumSet.noneOf(Permission.class);
+    private final Set<Permission> deny = EnumSet.noneOf(Permission.class);
+    private final OverrideType type;
+    private final String targetId;
+    
+    public PermissionOverrideData(@Nonnull final RoleData role) {
+        type = OverrideType.ROLE;
+        targetId = String.valueOf(role.id());
+    }
+    
+    public PermissionOverrideData(@Nonnull final OverrideType type, @Nonnull final String targetId) {
+        this.type = type;
+        this.targetId = targetId;
+    }
+    
+    public static PermissionOverrideData create(@Nonnull final RoleData role) {
+        return new PermissionOverrideData(role);
+    }
+    
+    public static PermissionOverrideData create(@Nonnull final Role role) {
+        return new PermissionOverrideData(OverrideType.ROLE, role.id());
+    }
+    
+    public static PermissionOverrideData create(@Nonnull final Member member) {
+        return new PermissionOverrideData(OverrideType.MEMBER, member.id());
+    }
+    
+    public static PermissionOverrideData create(@Nonnull final User user) {
+        return new PermissionOverrideData(OverrideType.MEMBER, user.id());
+    }
+    
+    public static PermissionOverrideData create(@Nonnull final PermissionOverride override) {
+        return new PermissionOverrideData(override.type(), override.id())
+                .allow(override.allow())
+                .deny(override.deny());
+    }
+    
+    public OverrideType type() {
+        return type;
+    }
+    
+    public PermissionOverrideData allow(@Nonnull final Permission... permissions) {
+        return allow(Arrays.asList(permissions));
+    }
+    
+    public PermissionOverrideData allow(@Nonnull final Collection<Permission> permissions) {
+        deny.removeAll(permissions);
+        allow.addAll(permissions);
+        return this;
+    }
+    
+    public PermissionOverrideData deny(@Nonnull final Permission... permissions) {
+        return deny(Arrays.asList(permissions));
+    }
+    
+    public PermissionOverrideData deny(@Nonnull final Collection<Permission> permissions) {
+        allow.removeAll(permissions);
+        deny.addAll(permissions);
+        return this;
+    }
+    
+    @Nonnull
+    @Override
+    public JsonObject toJson() {
+        return new JsonObject()
+                .put("id", targetId)
+                .put("type", type.getKey())
+                .put("allow", Permission.from(allow))
+                .put("deny", Permission.from(deny));
+    }
+}

--- a/src/main/java/com/mewna/catnip/rest/guild/RoleData.java
+++ b/src/main/java/com/mewna/catnip/rest/guild/RoleData.java
@@ -1,0 +1,111 @@
+package com.mewna.catnip.rest.guild;
+
+import com.mewna.catnip.util.JsonConvertible;
+import io.vertx.core.json.JsonObject;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+@Accessors(fluent = true)
+@Getter
+@Setter
+public class RoleData implements JsonConvertible {
+    private final int id;
+    private final boolean publicRole;
+    private Long permissions;
+    private String name;
+    private Integer color;
+    private Integer position;
+    private Boolean mentionable;
+    private Boolean hoisted;
+    
+    public RoleData(@Nonnegative final int id) {
+        this.id = id;
+        publicRole = id == 0;
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public static RoleData create(@Nonnegative final int id) {
+        if(id == 0) {
+            return new PublicRoleData();
+        }
+        return new RoleData(id);
+    }
+    
+    @Override
+    @Nonnull
+    @CheckReturnValue
+    public JsonObject toJson() {
+        final JsonObject object = new JsonObject().put("id", Integer.toString(id));
+        if(permissions != null) {
+            object.put("permissions", permissions);
+        }
+        if(name != null) {
+            object.put("name", name);
+        }
+        if(color != null) {
+            object.put("color", color & 0xFFFFFF);
+        }
+        if(position != null) {
+            object.put("position", position);
+        }
+        if(mentionable != null) {
+            object.put("mentionable", mentionable);
+        }
+        if(hoisted != null) {
+            object.put("hoisted", hoisted);
+        }
+        return object;
+    }
+    
+    @Override
+    public int hashCode() {
+        return id;
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof RoleData && ((RoleData) obj).id == id;
+    }
+    
+    @Override
+    public String toString() {
+        return "RoleData(id = " + id + ')';
+    }
+    
+    private static class PublicRoleData extends RoleData {
+        PublicRoleData() {
+            super(0);
+        }
+    
+        @Override
+        public RoleData name(final String name) {
+            throw new IllegalStateException("Cannot change name of public role");
+        }
+    
+        @Override
+        public RoleData color(final Integer color) {
+            throw new IllegalStateException("Cannot change color of public role");
+        }
+    
+        @Override
+        public RoleData position(final Integer position) {
+            throw new IllegalStateException("Cannot change position of public role");
+        }
+    
+        @Override
+        public RoleData mentionable(final Boolean mentionable) {
+            throw new IllegalStateException("Cannot change mentionable of public role");
+        }
+    
+        @Override
+        public RoleData hoisted(final Boolean mentionable) {
+            throw new IllegalStateException("Cannot change hoisted of public role");
+        }
+    }
+}

--- a/src/main/java/com/mewna/catnip/rest/guild/RoleData.java
+++ b/src/main/java/com/mewna/catnip/rest/guild/RoleData.java
@@ -1,5 +1,6 @@
 package com.mewna.catnip.rest.guild;
 
+import com.mewna.catnip.entity.util.Permission;
 import com.mewna.catnip.util.JsonConvertible;
 import io.vertx.core.json.JsonObject;
 import lombok.Getter;
@@ -9,6 +10,10 @@ import lombok.experimental.Accessors;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.LongUnaryOperator;
 
 @Accessors(fluent = true)
 @Getter
@@ -35,6 +40,52 @@ public class RoleData implements JsonConvertible {
             return new PublicRoleData();
         }
         return new RoleData(id);
+    }
+    
+    @Nonnull
+    public RoleData permissions(@Nullable final Long permissions) {
+        this.permissions = permissions;
+        return this;
+    }
+    
+    @Nonnull
+    public RoleData permissions(@Nonnull final Permission... permissions) {
+        return permissions(Permission.from(permissions));
+    }
+    
+    @Nonnull
+    public RoleData permissions(@Nonnull final Iterable<Permission> permissions) {
+        return permissions(Permission.from(permissions));
+    }
+    
+    @Nonnull
+    public RoleData addPermissions(@Nonnull final Permission... permissions) {
+        return addPermissions(Arrays.asList(permissions));
+    }
+    
+    @Nonnull
+    public RoleData addPermissions(@Nonnull final Iterable<Permission> permissions) {
+        //1101 | 0010
+        //1111
+        return updatePermissions(v->v | Permission.from(permissions));
+    }
+    
+    @Nonnull
+    public RoleData removePermissions(@Nonnull final Permission... permissions) {
+        return addPermissions(Arrays.asList(permissions));
+    }
+    
+    @Nonnull
+    public RoleData removePermissions(@Nonnull final Iterable<Permission> permissions) {
+        //1111 & ~0010
+        //1111 & 1101
+        //1101
+        return updatePermissions(v->v & ~Permission.from(permissions));
+    }
+    
+    @Nonnull
+    public RoleData updatePermissions(@Nonnull final LongUnaryOperator updater) {
+        return permissions(updater.applyAsLong(permissions == null ? 0 : permissions));
     }
     
     @Override

--- a/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
@@ -179,16 +179,6 @@ public class RestChannel extends RestHandler {
                 .thenApply(__ -> null);
     }
     
-    //TODO invite object
-    @Nonnull
-    @CheckReturnValue
-    public CompletableFuture<String> createInvite(@Nonnull final String channelId, @Nullable final InviteCreateOptions options) {
-        return getCatnip().requester().queue(new OutboundRequest(Routes.CREATE_CHANNEL_INVITE.withMajorParam(channelId),
-                ImmutableMap.of(), (options == null ? InviteCreateOptions.create() : options).toJson()))
-                .thenApply(ResponsePayload::object)
-                .thenApply(o->o.getString("code"));
-    }
-    
     @Nonnull
     @CheckReturnValue
     public CompletableFuture<Channel> getChannelById(@Nonnull final String channelId) {
@@ -214,5 +204,23 @@ public class RestChannel extends RestHandler {
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
                 .thenApply(getEntityBuilder()::createChannel);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<CreatedInvite> createInvite(@Nonnull final String channelId, @Nullable final InviteCreateOptions options) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.CREATE_CHANNEL_INVITE.withMajorParam(channelId),
+                ImmutableMap.of(), (options == null ? InviteCreateOptions.create() : options).toJson()))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createCreatedInvite);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<List<CreatedInvite>> getChannelInvites(@Nonnull final String channelId) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.GET_CHANNEL_INVITES.withMajorParam(channelId),
+                ImmutableMap.of(), null))
+                .thenApply(ResponsePayload::array)
+                .thenApply(mapObjectContents(getEntityBuilder()::createCreatedInvite));
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
@@ -90,6 +90,12 @@ public class RestChannel extends RestHandler {
     
     @Nonnull
     public CompletableFuture<Message> editMessage(@Nonnull final String channelId, @Nonnull final String messageId,
+                                                  @Nonnull final Embed embed) {
+        return editMessage(channelId, messageId, new MessageBuilder().embed(embed).build());
+    }
+    
+    @Nonnull
+    public CompletableFuture<Message> editMessage(@Nonnull final String channelId, @Nonnull final String messageId,
                                                   @Nonnull final Message message) {
         final JsonObject json = new JsonObject();
         if(message.content() != null && !message.content().isEmpty()) {
@@ -186,15 +192,6 @@ public class RestChannel extends RestHandler {
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
                 .thenApply(getEntityBuilder()::createChannel);
-    }
-    
-    @Nonnull
-    @CheckReturnValue
-    public CompletableFuture<DMChannel> createDM(@Nonnull final String recipientId) {
-        return getCatnip().requester().queue(new OutboundRequest(Routes.CREATE_DM,
-                ImmutableMap.of(), new JsonObject().put("recipient_id", recipientId)))
-                .thenApply(ResponsePayload::object)
-                .thenApply(getEntityBuilder()::createUserDM);
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
@@ -2,6 +2,7 @@ package com.mewna.catnip.rest.handler;
 
 import com.google.common.collect.ImmutableMap;
 import com.mewna.catnip.entity.*;
+import com.mewna.catnip.entity.GuildChannel.ChannelEditFields;
 import com.mewna.catnip.entity.builder.MessageBuilder;
 import com.mewna.catnip.internal.CatnipImpl;
 import com.mewna.catnip.rest.ResponsePayload;
@@ -219,5 +220,13 @@ public class RestChannel extends RestHandler {
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
                 .thenApply(mapObjectContents(getEntityBuilder()::createCreatedInvite));
+    }
+    
+    @Nonnull
+    public CompletableFuture<GuildChannel> modifyChannel(@Nonnull final String channelId, @Nonnull final ChannelEditFields fields) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.MODIFY_CHANNEL.withMajorParam(channelId),
+                ImmutableMap.of(), fields.payload()))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createGuildChannel);
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
@@ -9,6 +9,7 @@ import com.mewna.catnip.internal.CatnipImpl;
 import com.mewna.catnip.rest.ResponsePayload;
 import com.mewna.catnip.rest.RestRequester.OutboundRequest;
 import com.mewna.catnip.rest.Routes;
+import com.mewna.catnip.rest.invite.InviteCreateOptions;
 import io.vertx.core.json.JsonObject;
 
 import javax.annotation.CheckReturnValue;
@@ -178,5 +179,15 @@ public class RestChannel extends RestHandler {
         return getCatnip().requester().queue(new OutboundRequest(Routes.TRIGGER_TYPING_INDICATOR.withMajorParam(channelId),
                 ImmutableMap.of(), null))
                 .thenApply(__ -> null);
+    }
+    
+    //TODO invite object
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<String> createInvite(@Nonnull final String channelId, @Nullable final InviteCreateOptions options) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.CREATE_CHANNEL_INVITE.withMajorParam(channelId),
+                ImmutableMap.of(), (options == null ? InviteCreateOptions.create() : options).toJson()))
+                .thenApply(ResponsePayload::object)
+                .thenApply(o->o.getString("code"));
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestEmoji.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestEmoji.java
@@ -27,26 +27,26 @@ public class RestEmoji extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<List<Emoji>> listGuildEmojis(@Nonnull final String guildId) {
+    public CompletableFuture<List<CustomEmoji>> listGuildEmojis(@Nonnull final String guildId) {
         return getCatnip().requester().queue(
                 new OutboundRequest(
                         Routes.LIST_GUILD_EMOJIS.withMajorParam(guildId),
                         ImmutableMap.of(), null
                 ))
                 .thenApply(ResponsePayload::array)
-                .thenApply(mapObjectContents(getEntityBuilder()::createEmoji))
+                .thenApply(mapObjectContents(getEntityBuilder()::createCustomEmoji))
                 .thenApply(Collections::unmodifiableList);
     }
     
     @Nonnull
-    public CompletableFuture<Emoji> getGuildEmoji(@Nonnull final String guildId, @Nonnull final String emojiId) {
+    public CompletableFuture<CustomEmoji> getGuildEmoji(@Nonnull final String guildId, @Nonnull final String emojiId) {
         return getCatnip().requester().queue(
                 new OutboundRequest(
                         Routes.GET_GUILD_EMOJI.withMajorParam(guildId),
                         ImmutableMap.of("emoji.id", emojiId), null
                 ))
                 .thenApply(ResponsePayload::object)
-                .thenApply(getEntityBuilder()::createEmoji);
+                .thenApply(getEntityBuilder()::createCustomEmoji);
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
@@ -7,6 +7,7 @@ import com.mewna.catnip.internal.CatnipImpl;
 import com.mewna.catnip.rest.ResponsePayload;
 import com.mewna.catnip.rest.RestRequester.OutboundRequest;
 import com.mewna.catnip.rest.Routes;
+import com.mewna.catnip.rest.guild.PartialGuild;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -43,5 +44,23 @@ public class RestGuild extends RestHandler {
                         ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
                 .thenApply(getEntityBuilder()::createGuild);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<Guild> createGuild(@Nonnull final PartialGuild guild) {
+        return getCatnip().requester()
+                .queue(new OutboundRequest(Routes.CREATE_GUILD,
+                        ImmutableMap.of(), guild.toJson()))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createGuild);
+    }
+    
+    @Nonnull
+    public CompletableFuture<Void> deleteGuild(@Nonnull final String guildId) {
+        return getCatnip().requester()
+                .queue(new OutboundRequest(Routes.DELETE_GUILD.withMajorParam(guildId),
+                        ImmutableMap.of(), null))
+                .thenApply(__ -> null);
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
@@ -1,10 +1,7 @@
 package com.mewna.catnip.rest.handler;
 
 import com.google.common.collect.ImmutableMap;
-import com.mewna.catnip.entity.Channel;
-import com.mewna.catnip.entity.CreatedInvite;
-import com.mewna.catnip.entity.Guild;
-import com.mewna.catnip.entity.Role;
+import com.mewna.catnip.entity.*;
 import com.mewna.catnip.internal.CatnipImpl;
 import com.mewna.catnip.rest.ResponsePayload;
 import com.mewna.catnip.rest.RestRequester.OutboundRequest;
@@ -68,12 +65,15 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<Channel>> getGuildChannels(@Nonnull final String guildId) {
+    public CompletableFuture<List<GuildChannel>> getGuildChannels(@Nonnull final String guildId) {
         return getCatnip().requester()
                 .queue(new OutboundRequest(Routes.GET_GUILD_CHANNELS.withMajorParam(guildId),
                         ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
-                .thenApply(mapObjectContents(getEntityBuilder()::createChannel));
+                .thenApply(mapObjectContents(getEntityBuilder()::createChannel))
+                //all elements are guaranteed to be instances of GuildChannel,
+                //so it's safe to do a cast, plus this way we avoid copying the list.
+                .thenApply(RestHandler::uncheckedCast);
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
@@ -2,6 +2,7 @@ package com.mewna.catnip.rest.handler;
 
 import com.google.common.collect.ImmutableMap;
 import com.mewna.catnip.entity.Channel;
+import com.mewna.catnip.entity.CreatedInvite;
 import com.mewna.catnip.entity.Guild;
 import com.mewna.catnip.entity.Role;
 import com.mewna.catnip.internal.CatnipImpl;
@@ -73,5 +74,14 @@ public class RestGuild extends RestHandler {
                         ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
                 .thenApply(mapObjectContents(getEntityBuilder()::createChannel));
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<List<CreatedInvite>> getGuildInvites(@Nonnull final String guildId) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_INVITES.withMajorParam(guildId),
+                ImmutableMap.of(), null))
+                .thenApply(ResponsePayload::array)
+                .thenApply(mapObjectContents(getEntityBuilder()::createCreatedInvite));
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
@@ -1,6 +1,7 @@
 package com.mewna.catnip.rest.handler;
 
 import com.google.common.collect.ImmutableMap;
+import com.mewna.catnip.entity.Channel;
 import com.mewna.catnip.entity.Guild;
 import com.mewna.catnip.entity.Role;
 import com.mewna.catnip.internal.CatnipImpl;
@@ -62,5 +63,15 @@ public class RestGuild extends RestHandler {
                 .queue(new OutboundRequest(Routes.DELETE_GUILD.withMajorParam(guildId),
                         ImmutableMap.of(), null))
                 .thenApply(__ -> null);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<List<Channel>> getGuildChannels(@Nonnull final String guildId) {
+        return getCatnip().requester()
+                .queue(new OutboundRequest(Routes.GET_GUILD_CHANNELS.withMajorParam(guildId),
+                        ImmutableMap.of(), null))
+                .thenApply(ResponsePayload::array)
+                .thenApply(mapObjectContents(getEntityBuilder()::createChannel));
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
@@ -2,6 +2,7 @@ package com.mewna.catnip.rest.handler;
 
 import com.google.common.collect.ImmutableMap;
 import com.mewna.catnip.entity.*;
+import com.mewna.catnip.entity.Guild.GuildEditFields;
 import com.mewna.catnip.internal.CatnipImpl;
 import com.mewna.catnip.rest.ResponsePayload;
 import com.mewna.catnip.rest.RestRequester.OutboundRequest;
@@ -83,5 +84,13 @@ public class RestGuild extends RestHandler {
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
                 .thenApply(mapObjectContents(getEntityBuilder()::createCreatedInvite));
+    }
+    
+    @Nonnull
+    public CompletableFuture<Guild> modifyGuild(@Nonnull final String guildId, @Nonnull final GuildEditFields fields) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.MODIFY_GUILD.withMajorParam(guildId),
+                ImmutableMap.of(), fields.payload()))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createGuild);
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestHandler.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestHandler.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -33,7 +34,7 @@ abstract class RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    <T> Function<JsonArray, List<T>> mapObjectContents(@Nonnull final Function<JsonObject, T> builder) {
+    static <T> Function<JsonArray, List<T>> mapObjectContents(@Nonnull final Function<JsonObject, T> builder) {
         return array -> {
             final Collection<T> result = new ArrayList<>(array.size());
             for(final Object object : array) {
@@ -46,5 +47,10 @@ abstract class RestHandler {
             }
             return ImmutableList.copyOf(result);
         };
+    }
+    
+    @SuppressWarnings("unchecked")
+    static <T> T uncheckedCast(@Nullable final Object object) {
+        return (T)object;
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestInvite.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestInvite.java
@@ -1,0 +1,40 @@
+package com.mewna.catnip.rest.handler;
+
+import com.google.common.collect.ImmutableMap;
+import com.mewna.catnip.entity.Invite;
+import com.mewna.catnip.internal.CatnipImpl;
+import com.mewna.catnip.rest.ResponsePayload;
+import com.mewna.catnip.rest.RestRequester.OutboundRequest;
+import com.mewna.catnip.rest.Routes;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author natanbc
+ * @since 9/14/18
+ */
+public class RestInvite extends RestHandler {
+    public RestInvite(final CatnipImpl catnip) {
+        super(catnip);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<Invite> getInvite(@Nonnull final String code) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.GET_INVITE,
+                ImmutableMap.of("invite.code", code), null))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createInvite);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<Invite> deleteInvite(@Nonnull final String code) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_INVITE,
+                ImmutableMap.of("invite.code", code), null))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createInvite);
+    }
+}

--- a/src/main/java/com/mewna/catnip/rest/handler/RestUser.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestUser.java
@@ -1,11 +1,13 @@
 package com.mewna.catnip.rest.handler;
 
 import com.google.common.collect.ImmutableMap;
+import com.mewna.catnip.entity.DMChannel;
 import com.mewna.catnip.entity.User;
 import com.mewna.catnip.internal.CatnipImpl;
 import com.mewna.catnip.rest.ResponsePayload;
 import com.mewna.catnip.rest.RestRequester.OutboundRequest;
 import com.mewna.catnip.rest.Routes;
+import io.vertx.core.json.JsonObject;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -23,10 +25,35 @@ public class RestUser extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
+    public CompletableFuture<User> getCurrentUser() {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.GET_CURRENT_USER,
+                ImmutableMap.of(), null))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createUser);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
     public CompletableFuture<User> getUser(@Nonnull final String userId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_USER,
                 ImmutableMap.of("user.id", userId), null))
                 .thenApply(ResponsePayload::object)
                 .thenApply(getEntityBuilder()::createUser);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<DMChannel> createDM(@Nonnull final String recipientId) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.CREATE_DM,
+                ImmutableMap.of(), new JsonObject().put("recipient_id", recipientId)))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createUserDM);
+    }
+    
+    @Nonnull
+    public CompletableFuture<Void> leaveGuild(@Nonnull final String guildId) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.LEAVE_GUILD.withMajorParam(guildId),
+                ImmutableMap.of(), null))
+                .thenApply(__ -> null);
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestVoice.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestVoice.java
@@ -1,0 +1,28 @@
+package com.mewna.catnip.rest.handler;
+
+import com.google.common.collect.ImmutableMap;
+import com.mewna.catnip.entity.VoiceRegion;
+import com.mewna.catnip.internal.CatnipImpl;
+import com.mewna.catnip.rest.ResponsePayload;
+import com.mewna.catnip.rest.RestRequester.OutboundRequest;
+import com.mewna.catnip.rest.Routes;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class RestVoice extends RestHandler {
+    public RestVoice(final CatnipImpl catnip) {
+        super(catnip);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<List<VoiceRegion>> listVoiceRegions() {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.LIST_VOICE_REGIONS,
+                ImmutableMap.of(), null))
+                .thenApply(ResponsePayload::array)
+                .thenApply(mapObjectContents(getEntityBuilder()::createVoiceRegion));
+    }
+}

--- a/src/main/java/com/mewna/catnip/rest/handler/RestWebhook.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestWebhook.java
@@ -1,0 +1,58 @@
+package com.mewna.catnip.rest.handler;
+
+import com.google.common.collect.ImmutableMap;
+import com.mewna.catnip.entity.Webhook;
+import com.mewna.catnip.internal.CatnipImpl;
+import com.mewna.catnip.rest.ResponsePayload;
+import com.mewna.catnip.rest.RestRequester.OutboundRequest;
+import com.mewna.catnip.rest.Routes;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author natanbc
+ * @since 9/15/18
+ */
+public class RestWebhook extends RestHandler {
+    public RestWebhook(final CatnipImpl catnip) {
+        super(catnip);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<Webhook> getWebhook(@Nonnull final String webhookId) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.GET_WEBHOOK,
+                ImmutableMap.of("webhook.id", webhookId), null))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createWebhook);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<List<Webhook>> getGuildWebhooks(@Nonnull final String guildId) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_WEBHOOKS.withMajorParam(guildId),
+                ImmutableMap.of(), null))
+                .thenApply(ResponsePayload::array)
+                .thenApply(mapObjectContents(getEntityBuilder()::createWebhook));
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<List<Webhook>> getChannelWebhooks(@Nonnull final String channelId) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.GET_CHANNEL_WEBHOOKS.withMajorParam(channelId),
+                ImmutableMap.of(), null))
+                .thenApply(ResponsePayload::array)
+                .thenApply(mapObjectContents(getEntityBuilder()::createWebhook));
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    public CompletableFuture<Void> deleteWebhook(@Nonnull final String webhookId) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_WEBHOOK,
+                ImmutableMap.of("webhook.id", webhookId), null))
+                .thenApply(__ -> null);
+    }
+}

--- a/src/main/java/com/mewna/catnip/rest/handler/RestWebhook.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestWebhook.java
@@ -2,6 +2,7 @@ package com.mewna.catnip.rest.handler;
 
 import com.google.common.collect.ImmutableMap;
 import com.mewna.catnip.entity.Webhook;
+import com.mewna.catnip.entity.Webhook.WebhookEditFields;
 import com.mewna.catnip.internal.CatnipImpl;
 import com.mewna.catnip.rest.ResponsePayload;
 import com.mewna.catnip.rest.RestRequester.OutboundRequest;
@@ -24,8 +25,8 @@ public class RestWebhook extends RestHandler {
     @Nonnull
     @CheckReturnValue
     public CompletableFuture<Webhook> getWebhook(@Nonnull final String webhookId) {
-        return getCatnip().requester().queue(new OutboundRequest(Routes.GET_WEBHOOK,
-                ImmutableMap.of("webhook.id", webhookId), null))
+        return getCatnip().requester().queue(new OutboundRequest(Routes.GET_WEBHOOK.withMajorParam(webhookId),
+                ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
                 .thenApply(getEntityBuilder()::createWebhook);
     }
@@ -50,9 +51,18 @@ public class RestWebhook extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
+    public CompletableFuture<Webhook> modifyWebhook(@Nonnull final String webhookId, @Nonnull final WebhookEditFields fields) {
+        return getCatnip().requester().queue(new OutboundRequest(Routes.MODIFY_WEBHOOK.withMajorParam(webhookId),
+                ImmutableMap.of(), fields.payload()))
+                .thenApply(ResponsePayload::object)
+                .thenApply(getEntityBuilder()::createWebhook);
+    }
+    
+    @Nonnull
+    @CheckReturnValue
     public CompletableFuture<Void> deleteWebhook(@Nonnull final String webhookId) {
-        return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_WEBHOOK,
-                ImmutableMap.of("webhook.id", webhookId), null))
+        return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_WEBHOOK.withMajorParam(webhookId),
+                ImmutableMap.of(), null))
                 .thenApply(__ -> null);
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/invite/InviteCreateOptions.java
+++ b/src/main/java/com/mewna/catnip/rest/invite/InviteCreateOptions.java
@@ -1,0 +1,36 @@
+package com.mewna.catnip.rest.invite;
+
+import com.mewna.catnip.util.JsonConvertible;
+import io.vertx.core.json.JsonObject;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+@Accessors(fluent = true)
+@Getter
+@Setter
+public class InviteCreateOptions implements JsonConvertible {
+    private int maxAge;
+    private int maxUses;
+    private boolean temporary;
+    private boolean unique;
+    
+    @Nonnull
+    @CheckReturnValue
+    public static InviteCreateOptions create() {
+        return new InviteCreateOptions();
+    }
+    
+    @Nonnull
+    @Override
+    public JsonObject toJson() {
+        return new JsonObject()
+                .put("max_age", maxAge)
+                .put("max_uses", maxUses)
+                .put("temporary", temporary)
+                .put("unique", unique);
+    }
+}

--- a/src/main/java/com/mewna/catnip/util/CDNFormat.java
+++ b/src/main/java/com/mewna/catnip/util/CDNFormat.java
@@ -1,0 +1,65 @@
+package com.mewna.catnip.util;
+
+import com.mewna.catnip.entity.util.ImageOptions;
+import com.mewna.catnip.entity.util.ImageType;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * @author natanbc
+ * @since 9/14/18
+ */
+public final class CDNFormat {
+    private CDNFormat() {}
+    
+    @Nonnull
+    @CheckReturnValue
+    public static String defaultAvatarUrl(@Nonnull final String discriminator) {
+        final int avatarId = Short.parseShort(discriminator) % 5;
+        return String.format("https://cdn.discordapp.com/embed/avatars/%s.png", avatarId);
+    }
+    
+    @Nullable
+    @CheckReturnValue
+    public static String avatarUrl(@Nonnull final String id, @Nullable final String avatar, @Nonnull final ImageOptions options) {
+        if(avatar == null) {
+            return null;
+        }
+        if(options.getType() == ImageType.GIF && !avatar.startsWith("a_")) {
+            throw new IllegalArgumentException("Cannot build gif avatar URL for non gif avatar!");
+        }
+        return options.buildUrl(
+                String.format("https://cdn.discordapp.com/avatars/%s/%s", id, avatar)
+        );
+    }
+    
+    @Nullable
+    @CheckReturnValue
+    public static String iconUrl(@Nonnull final String id, @Nullable final String icon, @Nonnull final ImageOptions options) {
+        if(icon == null) {
+            return null;
+        }
+        if(options.getType() == ImageType.GIF) {
+            throw new IllegalArgumentException("Guild icons may not be GIFs");
+        }
+        return options.buildUrl(
+                String.format("https://cdn.discordapp.com/icons/%s/%s", id, icon)
+        );
+    }
+    
+    @Nullable
+    @CheckReturnValue
+    public static String splashUrl(@Nonnull final String id, @Nullable final String splash, @Nonnull final ImageOptions options) {
+        if(splash == null) {
+            return null;
+        }
+        if(options.getType() == ImageType.GIF) {
+            throw new IllegalArgumentException("Guild icons may not be GIFs");
+        }
+        return options.buildUrl(
+                String.format("https://cdn.discordapp.com/splashes/%s/%s", id, splash)
+        );
+    }
+}

--- a/src/main/java/com/mewna/catnip/util/JsonConvertible.java
+++ b/src/main/java/com/mewna/catnip/util/JsonConvertible.java
@@ -1,0 +1,13 @@
+package com.mewna.catnip.util;
+
+import io.vertx.core.json.JsonObject;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+@FunctionalInterface
+public interface JsonConvertible {
+    @Nonnull
+    @CheckReturnValue
+    JsonObject toJson();
+}

--- a/src/test/java/com/mewna/catnip/permission/BitwiseTest.java
+++ b/src/test/java/com/mewna/catnip/permission/BitwiseTest.java
@@ -1,6 +1,6 @@
 package com.mewna.catnip.permission;
 
-import com.mewna.catnip.entity.impl.Permission;
+import com.mewna.catnip.entity.util.Permission;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static com.mewna.catnip.entity.impl.Permission.*;
+import static com.mewna.catnip.entity.util.Permission.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
## Channels
- [x] Add entities for channels
- [x] Support getting all guild channels (`GET_GUILD_CHANNELS` route)
- [x] Support getting a channel by id (`GET_CHANNEL` route)
- [x] Support deleting channels (`DELETE_CHANNEL` route)
- [x] Support modifying channels (`MODIFY_CHANNEL` route)
- [x] Support permission overrides
- [x] Support for creating/modifying webhooks

## Guild creation
- [x] Support creating guilds (`CREATE_GUILD` route)
- [x] Support creating roles at guild creation
- [x] Support creating channels at guild creation
- [x] Support creating permission overrides on channels

## Invites
- [x] Support for creating invites (`CREATE_CHANNEL_INVITE` route)
- [x] Support for getting invites by code (`GET_INVITE` route)
- [x] Support for listing channel invites (`GET_CHANNEL_INVITES` route)
- [x] Support for listing guild invites (`GET_GUILD_INVITES` route)
- [x] Support for deleting invites (`DELETE_INVITE` route)

## Webhooks
- [x] Support for getting webhooks by id (`GET_WEBHOOK` route)
- [x] Support for getting guild webhooks (`GET_GUILD_WEBHOOKS` route)
- [x] Support for getting channel webhooks (`GET_CHANNEL_WEBHOOKS` route)
- [x] Support for deleting webhooks (`DELETE_WEBHOOK` route)
- [x] Support for modifying webhooks (`MODIFY_WEBHOOK` route)

## Others
- Support deleting guilds (`DELETE_GUILD` route)
- Support for leaving guilds (`LEAVE_GUILD` route)
- Support for getting current user (`GET_CURRENT_USER` route)
- Support for listing voice regions (`LIST_VOICE_REGIONS` route)
- Support for modifying guilds (`MODIFY_GUILD` route)
- Shortcut methods on entities instead of manually calling Rest\* classes