### PR TITLE
fix a couple errors

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -641,7 +641,7 @@ public final class EntityBuilder {
         return VoiceServerUpdateImpl.builder()
                 .catnip(catnip)
                 .token(data.getString("token"))
-                .guildId(data.getString("guildId"))
+                .guildId(data.getString("guild_id"))
                 .endpoint(data.getString("endpoint"))
                 .build();
     }

--- a/src/main/java/com/mewna/catnip/entity/user/Presence.java
+++ b/src/main/java/com/mewna/catnip/entity/user/Presence.java
@@ -61,7 +61,8 @@ public interface Presence {
     enum ActivityType {
         PLAYING(0),
         STREAMING(1),
-        LISTENING(2),;
+        LISTENING(2),
+        WATCHING(3),;
         @Getter
         private final int id;
         

--- a/src/main/java/com/mewna/catnip/shard/DispatchEmitter.java
+++ b/src/main/java/com/mewna/catnip/shard/DispatchEmitter.java
@@ -139,7 +139,7 @@ public class DispatchEmitter {
                 break;
             }
             case Raw.GUILD_MEMBER_REMOVE: {
-                catnip.eventBus().send(type, entityBuilder.createMember(data.getString("guild_id"), data.getJsonObject("user")));
+                catnip.eventBus().send(type, entityBuilder.createMember(data.getString("guild_id"), data));
                 break;
             }
             case Raw.GUILD_MEMBER_UPDATE: {


### PR DESCRIPTION
- Fixes errors when activity type 3 (watching) is received
- Fixes errors when building a member object for GUILD_MEMBER_REMOVE events
- Fixes voice states sent with the GUILD_CREATE payloads not being cached due to missing `guild_id` field