### PR TITLE
Convert CompletableFuture<T>s to CompletionStage<T>s

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/channel/Channel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/Channel.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author natanbc
@@ -18,7 +18,7 @@ public interface Channel extends Snowflake {
     ChannelType type();
     
     @Nonnull
-    default CompletableFuture<Channel> delete() {
+    default CompletionStage<Channel> delete() {
         return catnip().rest().channel().deleteChannel(id());
     }
     
@@ -63,7 +63,7 @@ public interface Channel extends Snowflake {
         if(!isGuild()) {
             throw new UnsupportedOperationException("Not a guild channel");
         }
-        return (GuildChannel)this;
+        return (GuildChannel) this;
     }
     
     @Nonnull
@@ -72,7 +72,7 @@ public interface Channel extends Snowflake {
         if(!isText()) {
             throw new UnsupportedOperationException("Not a text channel");
         }
-        return (TextChannel)this;
+        return (TextChannel) this;
     }
     
     @Nonnull
@@ -81,7 +81,7 @@ public interface Channel extends Snowflake {
         if(!isVoice()) {
             throw new UnsupportedOperationException("Not a voice channel");
         }
-        return (VoiceChannel)this;
+        return (VoiceChannel) this;
     }
     
     @Nonnull
@@ -90,7 +90,7 @@ public interface Channel extends Snowflake {
         if(!isCategory()) {
             throw new UnsupportedOperationException("Not a category");
         }
-        return (Category)this;
+        return (Category) this;
     }
     
     @Nonnull
@@ -99,7 +99,7 @@ public interface Channel extends Snowflake {
         if(!isDM()) {
             throw new UnsupportedOperationException("Not a DM channel");
         }
-        return (DMChannel)this;
+        return (DMChannel) this;
     }
     
     @Nonnull
@@ -108,7 +108,7 @@ public interface Channel extends Snowflake {
         if(!isUserDM()) {
             throw new UnsupportedOperationException("Not an user DM channel");
         }
-        return (UserDMChannel)this;
+        return (UserDMChannel) this;
     }
     
     @Nonnull
@@ -117,7 +117,7 @@ public interface Channel extends Snowflake {
         if(!isGroupDM()) {
             throw new UnsupportedOperationException("Not a group DM channel");
         }
-        return (GroupDMChannel)this;
+        return (GroupDMChannel) this;
     }
     
     enum ChannelType {
@@ -132,7 +132,7 @@ public interface Channel extends Snowflake {
             this.key = key;
             this.guild = guild;
         }
-    
+        
         @Nonnull
         public static ChannelType byKey(final int key) {
             for(final ChannelType level : values()) {

--- a/src/main/java/com/mewna/catnip/entity/channel/MessageChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/MessageChannel.java
@@ -7,77 +7,78 @@ import com.mewna.catnip.entity.misc.Emoji;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
+@SuppressWarnings("unused")
 public interface MessageChannel extends Channel {
     @Nonnull
-    default CompletableFuture<Message> sendMessage(@Nonnull final String content) {
+    default CompletionStage<Message> sendMessage(@Nonnull final String content) {
         return catnip().rest().channel().sendMessage(id(), content);
     }
     
     @Nonnull
-    default CompletableFuture<Message> sendMessage(@Nonnull final Embed embed) {
+    default CompletionStage<Message> sendMessage(@Nonnull final Embed embed) {
         return catnip().rest().channel().sendMessage(id(), embed);
     }
     
     @Nonnull
-    default CompletableFuture<Message> sendMessage(@Nonnull final Message message) {
+    default CompletionStage<Message> sendMessage(@Nonnull final Message message) {
         return catnip().rest().channel().sendMessage(id(), message);
     }
     
     @Nonnull
-    default CompletableFuture<Message> sendMessage(@Nonnull final MessageOptions options) {
+    default CompletionStage<Message> sendMessage(@Nonnull final MessageOptions options) {
         return catnip().rest().channel().sendMessage(id(), options);
     }
     
     @Nonnull
-    default CompletableFuture<Message> editMessage(@Nonnull final String messageId, @Nonnull final String content) {
+    default CompletionStage<Message> editMessage(@Nonnull final String messageId, @Nonnull final String content) {
         return catnip().rest().channel().editMessage(id(), messageId, content);
     }
     
     @Nonnull
-    default CompletableFuture<Message> editMessage(@Nonnull final String messageId, @Nonnull final Embed embed) {
+    default CompletionStage<Message> editMessage(@Nonnull final String messageId, @Nonnull final Embed embed) {
         return catnip().rest().channel().editMessage(id(), messageId, embed);
     }
     
     @Nonnull
-    default CompletableFuture<Message> editMessage(@Nonnull final String messageId, @Nonnull final Message message) {
+    default CompletionStage<Message> editMessage(@Nonnull final String messageId, @Nonnull final Message message) {
         return catnip().rest().channel().editMessage(id(), messageId, message);
     }
     
     @Nonnull
-    default CompletableFuture<Void> deleteMessage(@Nonnull final String messageId) {
+    default CompletionStage<Void> deleteMessage(@Nonnull final String messageId) {
         return catnip().rest().channel().deleteMessage(id(), messageId);
     }
     
     @Nonnull
-    default CompletableFuture<Void> addReaction(@Nonnull final String messageId, @Nonnull final String emoji) {
+    default CompletionStage<Void> addReaction(@Nonnull final String messageId, @Nonnull final String emoji) {
         return catnip().rest().channel().addReaction(id(), messageId, emoji);
     }
     
     @Nonnull
-    default CompletableFuture<Void> addReaction(@Nonnull final String messageId, @Nonnull final Emoji emoji) {
+    default CompletionStage<Void> addReaction(@Nonnull final String messageId, @Nonnull final Emoji emoji) {
         return catnip().rest().channel().addReaction(id(), messageId, emoji);
     }
     
     @Nonnull
-    default CompletableFuture<Void> deleteOwnReaction(@Nonnull final String messageId, @Nonnull final String emoji) {
+    default CompletionStage<Void> deleteOwnReaction(@Nonnull final String messageId, @Nonnull final String emoji) {
         return catnip().rest().channel().deleteOwnReaction(id(), messageId, emoji);
     }
     
     @Nonnull
-    default CompletableFuture<Void> deleteOwnReaction(@Nonnull final String messageId, @Nonnull final Emoji emoji) {
+    default CompletionStage<Void> deleteOwnReaction(@Nonnull final String messageId, @Nonnull final Emoji emoji) {
         return catnip().rest().channel().deleteOwnReaction(id(), messageId, emoji);
     }
     
     @Nonnull
-    default CompletableFuture<Void> triggerTypingIndicator() {
+    default CompletionStage<Void> triggerTypingIndicator() {
         return catnip().rest().channel().triggerTypingIndicator(id());
     }
     
     @Nonnull
     @CheckReturnValue
-    default CompletableFuture<Message> fetchMessage(@Nonnull final String messageId) {
+    default CompletionStage<Message> fetchMessage(@Nonnull final String messageId) {
         return catnip().rest().channel().getMessage(id(), messageId);
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/channel/TextChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/TextChannel.java
@@ -5,12 +5,13 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author natanbc
  * @since 9/12/18
  */
+@SuppressWarnings("unused")
 public interface TextChannel extends GuildChannel, MessageChannel {
     @Nullable
     @CheckReturnValue
@@ -43,7 +44,7 @@ public interface TextChannel extends GuildChannel, MessageChannel {
     
     @Nonnull
     @CheckReturnValue
-    default CompletableFuture<List<Webhook>> fetchWebhooks() {
+    default CompletionStage<List<Webhook>> fetchWebhooks() {
         return catnip().rest().webhook().getChannelWebhooks(id());
     }
     

--- a/src/main/java/com/mewna/catnip/entity/channel/Webhook.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/Webhook.java
@@ -12,12 +12,13 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author natanbc
  * @since 9/15/18
  */
+@SuppressWarnings("unused")
 public interface Webhook extends Snowflake {
     @Nonnull
     @CheckReturnValue
@@ -51,10 +52,11 @@ public interface Webhook extends Snowflake {
     
     @Nonnull
     @CheckReturnValue
-    default CompletableFuture<Void> delete() {
+    default CompletionStage<Void> delete() {
         return catnip().rest().webhook().deleteWebhook(id());
     }
     
+    @SuppressWarnings("unused")
     @Getter
     @Setter
     @Accessors(fluent = true)
@@ -73,7 +75,7 @@ public interface Webhook extends Snowflake {
         }
     
         @Nonnull
-        public CompletableFuture<Webhook> submit() {
+        public CompletionStage<Webhook> submit() {
             if(webhook == null) {
                 throw new IllegalStateException("Cannot submit edit without a webhook object! Please use RestWebhook directly instead");
             }

--- a/src/main/java/com/mewna/catnip/entity/guild/Guild.java
+++ b/src/main/java/com/mewna/catnip/entity/guild/Guild.java
@@ -24,12 +24,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author natanbc
  * @since 9/6/18
  */
+@SuppressWarnings("unused")
 public interface Guild extends Snowflake {
     @Nonnull
     @CheckReturnValue
@@ -165,70 +166,70 @@ public interface Guild extends Snowflake {
     
     @Nonnull
     @CheckReturnValue
-    default CompletableFuture<List<Role>> fetchRoles() {
+    default CompletionStage<List<Role>> fetchRoles() {
         return catnip().rest().guild().getGuildRoles(id());
     }
     
     @Nonnull
     @CheckReturnValue
-    default CompletableFuture<List<GuildChannel>> fetchChannels() {
+    default CompletionStage<List<GuildChannel>> fetchChannels() {
         return catnip().rest().guild().getGuildChannels(id());
     }
     
     @Nonnull
     @CheckReturnValue
-    default CompletableFuture<List<CreatedInvite>> fetchInvites() {
+    default CompletionStage<List<CreatedInvite>> fetchInvites() {
         return catnip().rest().guild().getGuildInvites(id());
     }
     
     @Nonnull
     @CheckReturnValue
-    default CompletableFuture<List<Webhook>> fetchWebhooks() {
+    default CompletionStage<List<Webhook>> fetchWebhooks() {
         return catnip().rest().webhook().getGuildWebhooks(id());
     }
     
     @Nonnull
     @CheckReturnValue
-    default CompletableFuture<List<CustomEmoji>> fetchEmojis() {
+    default CompletionStage<List<CustomEmoji>> fetchEmojis() {
         return catnip().rest().emoji().listGuildEmojis(id());
     }
     
     @Nonnull
     @CheckReturnValue
-    default CompletableFuture<CustomEmoji> fetchEmoji(@Nonnull final String emojiId) {
+    default CompletionStage<CustomEmoji> fetchEmoji(@Nonnull final String emojiId) {
         return catnip().rest().emoji().getGuildEmoji(id(), emojiId);
     }
     
     @Nonnull
-    default CompletableFuture<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final byte[] image,
+    default CompletionStage<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final byte[] image,
                                                        @Nonnull final Collection<String> roles) {
         return catnip().rest().emoji().createGuildEmoji(id(), name, image, roles);
     }
     
     @Nonnull
-    default CompletableFuture<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final URI imageData,
+    default CompletionStage<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final URI imageData,
                                                        @Nonnull final Collection<String> roles) {
         return catnip().rest().emoji().createGuildEmoji(id(), name, imageData, roles);
     }
     
     @Nonnull
-    default CompletableFuture<CustomEmoji> modifyEmoji(@Nonnull final String emojiId, @Nonnull final String name,
+    default CompletionStage<CustomEmoji> modifyEmoji(@Nonnull final String emojiId, @Nonnull final String name,
                                                        @Nonnull final Collection<String> roles) {
         return catnip().rest().emoji().modifyGuildEmoji(id(), emojiId, name, roles);
     }
     
     @Nonnull
-    default CompletableFuture<Void> deleteEmoji(@Nonnull final String emojiId) {
+    default CompletionStage<Void> deleteEmoji(@Nonnull final String emojiId) {
         return catnip().rest().emoji().deleteGuildEmoji(id(), emojiId);
     }
     
     @Nonnull
-    default CompletableFuture<Void> leave() {
+    default CompletionStage<Void> leave() {
         return catnip().rest().user().leaveGuild(id());
     }
     
     @Nonnull
-    default CompletableFuture<Void> delete() {
+    default CompletionStage<Void> delete() {
         return catnip().rest().guild().deleteGuild(id());
     }
     
@@ -332,6 +333,7 @@ public interface Guild extends Snowflake {
         }
     }
     
+    @SuppressWarnings("unused")
     @Getter
     @Setter
     @Accessors(fluent = true)
@@ -386,7 +388,7 @@ public interface Guild extends Snowflake {
         }
         
         @Nonnull
-        public CompletableFuture<Guild> submit() {
+        public CompletionStage<Guild> submit() {
             if(guild == null) {
                 throw new IllegalStateException("Cannot submit edit without a guild object! Please use RestGuild directly instead");
             }
@@ -403,13 +405,13 @@ public interface Guild extends Snowflake {
             if(region != null && (guild == null || !Objects.equals(region, guild.region()))) {
                 payload.put("region", region);
             }
-            if(verificationLevel != null && (guild == null || !Objects.equals(verificationLevel, guild.verificationLevel()))) {
+            if(verificationLevel != null && (guild == null || verificationLevel != guild.verificationLevel())) {
                 payload.put("verification_level", verificationLevel.getKey());
             }
-            if(defaultMessageNotifications != null && (guild == null || !Objects.equals(defaultMessageNotifications, guild.defaultMessageNotifications()))) {
+            if(defaultMessageNotifications != null && (guild == null || defaultMessageNotifications != guild.defaultMessageNotifications())) {
                 payload.put("default_message_notifications", defaultMessageNotifications.getKey());
             }
-            if(explicitContentFilter != null && (guild == null || !Objects.equals(explicitContentFilter, guild.explicitContentFilter()))) {
+            if(explicitContentFilter != null && (guild == null || explicitContentFilter != guild.explicitContentFilter())) {
                 payload.put("explicit_content_filter", explicitContentFilter.getKey());
             }
             if(afkChannelId != null && (guild == null || !Objects.equals(afkChannelId, guild.afkChannelId()))) {

--- a/src/main/java/com/mewna/catnip/entity/guild/Invite.java
+++ b/src/main/java/com/mewna/catnip/entity/guild/Invite.java
@@ -10,12 +10,13 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author natanbc
  * @since 9/14/18
  */
+@SuppressWarnings("unused")
 public interface Invite extends Entity {
     @Nonnull
     @CheckReturnValue
@@ -34,10 +35,11 @@ public interface Invite extends Entity {
     InviteChannel channel();
     
     int approximatePresenceCount();
+    
     int approximateMemberCount();
     
     @Nonnull
-    default CompletableFuture<Invite> delete() {
+    default CompletionStage<Invite> delete() {
         return catnip().rest().invite().deleteInvite(code());
     }
     
@@ -49,7 +51,7 @@ public interface Invite extends Entity {
         @Nonnull
         @CheckReturnValue
         String username();
-    
+        
         @Nonnull
         @CheckReturnValue
         String discriminator();
@@ -60,7 +62,7 @@ public interface Invite extends Entity {
         
         @CheckReturnValue
         boolean animatedAvatar();
-    
+        
         @Nonnull
         @CheckReturnValue
         String defaultAvatarUrl();
@@ -68,13 +70,15 @@ public interface Invite extends Entity {
         @Nullable
         @CheckReturnValue
         String avatarUrl(@Nonnull ImageOptions options);
+        
         @Nullable
         @CheckReturnValue
         String avatarUrl();
-    
+        
         @Nonnull
         @CheckReturnValue
         String effectiveAvatarUrl(@Nonnull ImageOptions options);
+        
         @Nonnull
         @CheckReturnValue
         String effectiveAvatarUrl();
@@ -84,15 +88,15 @@ public interface Invite extends Entity {
         @Nonnull
         @CheckReturnValue
         String id();
-    
+        
         @Nonnull
         @CheckReturnValue
         String name();
-    
+        
         @Nullable
         @CheckReturnValue
         String icon();
-    
+        
         @Nullable
         @CheckReturnValue
         String splash();
@@ -104,19 +108,21 @@ public interface Invite extends Entity {
         @Nonnull
         @CheckReturnValue
         VerificationLevel verificationLevel();
-    
+        
         @Nullable
         @CheckReturnValue
         String iconUrl(@Nonnull ImageOptions options);
+        
         @Nullable
         @CheckReturnValue
         default String iconUrl() {
             return iconUrl(new ImageOptions());
         }
-    
+        
         @Nullable
         @CheckReturnValue
         String splashUrl(@Nonnull ImageOptions options);
+        
         @Nullable
         @CheckReturnValue
         default String splashUrl() {
@@ -128,7 +134,7 @@ public interface Invite extends Entity {
         @Nonnull
         @CheckReturnValue
         String id();
-    
+        
         @Nonnull
         @CheckReturnValue
         String name();

--- a/src/main/java/com/mewna/catnip/entity/guild/Member.java
+++ b/src/main/java/com/mewna/catnip/entity/guild/Member.java
@@ -7,7 +7,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author amy
@@ -82,7 +82,7 @@ public interface Member extends Snowflake {
      *
      * @return Future with the result of the DM creation.
      */
-    default CompletableFuture<DMChannel> createDM() {
+    default CompletionStage<DMChannel> createDM() {
         return catnip().rest().user().createDM(id());
     }
 }

--- a/src/main/java/com/mewna/catnip/entity/message/Message.java
+++ b/src/main/java/com/mewna/catnip/entity/message/Message.java
@@ -11,12 +11,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author amy
  * @since 9/4/18.
  */
+@SuppressWarnings("unused")
 public interface Message extends Snowflake {
     /**
      * The type of message. Use this to tell normal messages from system messages.
@@ -189,7 +190,7 @@ public interface Message extends Snowflake {
      * @return Future for the reaction.
      */
     @Nonnull
-    default CompletableFuture<Void> react(@Nonnull final Emoji emoji) {
+    default CompletionStage<Void> react(@Nonnull final Emoji emoji) {
         return catnip().rest().channel().addReaction(channelId(), id(), emoji);
     }
     
@@ -202,27 +203,27 @@ public interface Message extends Snowflake {
      * @return Future for the reaction.
      */
     @Nonnull
-    default CompletableFuture<Void> react(@Nonnull final String emoji) {
+    default CompletionStage<Void> react(@Nonnull final String emoji) {
         return catnip().rest().channel().addReaction(channelId(), id(), emoji);
     }
     
     @Nonnull
-    default CompletableFuture<Void> delete() {
+    default CompletionStage<Void> delete() {
         return catnip().rest().channel().deleteMessage(channelId(), id());
     }
     
     @Nonnull
-    default CompletableFuture<Message> edit(@Nonnull final String content) {
+    default CompletionStage<Message> edit(@Nonnull final String content) {
         return catnip().rest().channel().editMessage(channelId(), id(), content);
     }
     
     @Nonnull
-    default CompletableFuture<Message> edit(@Nonnull final Embed embed) {
+    default CompletionStage<Message> edit(@Nonnull final Embed embed) {
         return catnip().rest().channel().editMessage(channelId(), id(), embed);
     }
     
     @Nonnull
-    default CompletableFuture<Message> edit(@Nonnull final Message message) {
+    default CompletionStage<Message> edit(@Nonnull final Message message) {
         return catnip().rest().channel().editMessage(channelId(), id(), message);
     }
     

--- a/src/main/java/com/mewna/catnip/entity/user/User.java
+++ b/src/main/java/com/mewna/catnip/entity/user/User.java
@@ -7,12 +7,13 @@ import com.mewna.catnip.entity.util.ImageOptions;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author amy
  * @since 9/4/18
  */
+@SuppressWarnings("unused")
 public interface User extends Snowflake {
     /**
      * Whether the user's avatar is animated.
@@ -133,7 +134,7 @@ public interface User extends Snowflake {
      *
      * @return Future with the result of the DM creation.
      */
-    default CompletableFuture<DMChannel> createDM() {
+    default CompletionStage<DMChannel> createDM() {
         return catnip().rest().user().createDM(id());
     }
     

--- a/src/main/java/com/mewna/catnip/rest/RestRequester.java
+++ b/src/main/java/com/mewna/catnip/rest/RestRequester.java
@@ -26,10 +26,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import static io.vertx.core.http.HttpMethod.GET;
 
@@ -58,7 +55,7 @@ public class RestRequester {
         this.bucketBackend = bucketBackend;
     }
     
-    public CompletableFuture<ResponsePayload> queue(final OutboundRequest r) {
+    public CompletionStage<ResponsePayload> queue(final OutboundRequest r) {
         final Future<ResponsePayload> future = Future.future();
         getBucket(r.route.baseRoute()).queue(future, r);
         return VertxCompletableFuture.from(catnip.vertx(), future);

--- a/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -47,17 +46,17 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Message> sendMessage(@Nonnull final String channelId, @Nonnull final String content) {
+    public CompletionStage<Message> sendMessage(@Nonnull final String channelId, @Nonnull final String content) {
         return sendMessage(channelId, new MessageBuilder().content(content).build());
     }
     
     @Nonnull
-    public CompletableFuture<Message> sendMessage(@Nonnull final String channelId, @Nonnull final Embed embed) {
+    public CompletionStage<Message> sendMessage(@Nonnull final String channelId, @Nonnull final Embed embed) {
         return sendMessage(channelId, new MessageBuilder().embed(embed).build());
     }
     
     @Nonnull
-    public CompletableFuture<Message> sendMessage(@Nonnull final String channelId, @Nonnull final Message message) {
+    public CompletionStage<Message> sendMessage(@Nonnull final String channelId, @Nonnull final Message message) {
         final JsonObject json = new JsonObject();
         if(message.content() != null && !message.content().isEmpty()) {
             json.put("content", message.content());
@@ -76,7 +75,7 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public final CompletableFuture<Message> sendMessage(@Nonnull final String channelId, @Nonnull final MessageOptions options) {
+    public final CompletionStage<Message> sendMessage(@Nonnull final String channelId, @Nonnull final MessageOptions options) {
         final JsonObject json = new JsonObject();
         
         if(options.content() != null && !options.content().isEmpty()) {
@@ -99,7 +98,7 @@ public class RestChannel extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Message> getMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
+    public CompletionStage<Message> getMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
         return getCatnip().requester().queue(
                 new OutboundRequest(Routes.GET_CHANNEL_MESSAGE.withMajorParam(channelId),
                         ImmutableMap.of("message.id", messageId), null))
@@ -108,20 +107,20 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Message> editMessage(@Nonnull final String channelId, @Nonnull final String messageId,
-                                                  @Nonnull final String content) {
+    public CompletionStage<Message> editMessage(@Nonnull final String channelId, @Nonnull final String messageId,
+                                                @Nonnull final String content) {
         return editMessage(channelId, messageId, new MessageBuilder().content(content).build());
     }
     
     @Nonnull
-    public CompletableFuture<Message> editMessage(@Nonnull final String channelId, @Nonnull final String messageId,
-                                                  @Nonnull final Embed embed) {
+    public CompletionStage<Message> editMessage(@Nonnull final String channelId, @Nonnull final String messageId,
+                                                @Nonnull final Embed embed) {
         return editMessage(channelId, messageId, new MessageBuilder().embed(embed).build());
     }
     
     @Nonnull
-    public CompletableFuture<Message> editMessage(@Nonnull final String channelId, @Nonnull final String messageId,
-                                                  @Nonnull final Message message) {
+    public CompletionStage<Message> editMessage(@Nonnull final String channelId, @Nonnull final String messageId,
+                                                @Nonnull final Message message) {
         final JsonObject json = new JsonObject();
         if(message.content() != null && !message.content().isEmpty()) {
             json.put("content", message.content());
@@ -140,13 +139,13 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> deleteMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
+    public CompletionStage<Void> deleteMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_MESSAGE.withMajorParam(channelId),
                 ImmutableMap.of("message.id", messageId), null)).thenApply(__ -> null);
     }
     
     @Nonnull
-    public CompletableFuture<Void> deleteMessages(@Nonnull final String channelId, @Nonnull final List<String> messageIds) {
+    public CompletionStage<Void> deleteMessages(@Nonnull final String channelId, @Nonnull final List<String> messageIds) {
         return getCatnip().requester()
                 .queue(new OutboundRequest(Routes.BULK_DELETE_MESSAGES.withMajorParam(channelId),
                         ImmutableMap.of(), new JsonObject().put("messages", new JsonArray(messageIds))))
@@ -154,35 +153,35 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> addReaction(@Nonnull final String channelId, @Nonnull final String messageId,
-                                               @Nonnull final String emoji) {
+    public CompletionStage<Void> addReaction(@Nonnull final String channelId, @Nonnull final String messageId,
+                                             @Nonnull final String emoji) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.CREATE_REACTION.withMajorParam(channelId),
                 ImmutableMap.of("message.id", messageId, "emojis", encodeUTF8(emoji)), new JsonObject()))
                 .thenApply(__ -> null);
     }
     
     @Nonnull
-    public CompletableFuture<Void> addReaction(@Nonnull final String channelId, @Nonnull final String messageId,
-                                               @Nonnull final Emoji emoji) {
+    public CompletionStage<Void> addReaction(@Nonnull final String channelId, @Nonnull final String messageId,
+                                             @Nonnull final Emoji emoji) {
         return addReaction(channelId, messageId, emoji.forReaction());
     }
     
     @Nonnull
-    public CompletableFuture<Void> deleteOwnReaction(@Nonnull final String channelId, @Nonnull final String messageId,
-                                                     @Nonnull final String emoji) {
+    public CompletionStage<Void> deleteOwnReaction(@Nonnull final String channelId, @Nonnull final String messageId,
+                                                   @Nonnull final String emoji) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_OWN_REACTION.withMajorParam(channelId),
                 ImmutableMap.of("message.id", messageId, "emojis", encodeUTF8(emoji)), null))
                 .thenApply(__ -> null);
     }
     
     @Nonnull
-    public CompletableFuture<Void> deleteOwnReaction(@Nonnull final String channelId, @Nonnull final String messageId,
-                                                     @Nonnull final Emoji emoji) {
+    public CompletionStage<Void> deleteOwnReaction(@Nonnull final String channelId, @Nonnull final String messageId,
+                                                   @Nonnull final Emoji emoji) {
         return deleteOwnReaction(channelId, messageId, emoji.forReaction());
     }
     
     @Nonnull
-    public CompletableFuture<Void> deleteAllReactions(@Nonnull final String channelId, @Nonnull final String messageId) {
+    public CompletionStage<Void> deleteAllReactions(@Nonnull final String channelId, @Nonnull final String messageId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_ALL_REACTIONS.withMajorParam(channelId),
                 ImmutableMap.of("message.id", messageId), null))
                 .thenApply(__ -> null);
@@ -191,7 +190,7 @@ public class RestChannel extends RestHandler {
     @Nonnull
     @CheckReturnValue
     public ReactionPaginator getReactions(@Nonnull final String channelId, @Nonnull final String messageId,
-                                            @Nonnull final String emoji) {
+                                          @Nonnull final String emoji) {
         return new ReactionPaginator(getEntityBuilder()) {
             @Nonnull
             @CheckReturnValue
@@ -206,7 +205,7 @@ public class RestChannel extends RestHandler {
     @Nonnull
     @CheckReturnValue
     public ReactionPaginator getReactions(@Nonnull final String channelId, @Nonnull final String messageId,
-                                            @Nonnull final Emoji emoji) {
+                                          @Nonnull final Emoji emoji) {
         return getReactions(channelId, messageId, emoji.forReaction());
     }
     
@@ -214,21 +213,21 @@ public class RestChannel extends RestHandler {
     //keeping this private for consistency with the rest of the methods
     @Nonnull
     @CheckReturnValue
-    private CompletableFuture<JsonArray> getReactionsRaw(@Nonnull final String channelId, @Nonnull final String messageId,
-                                                      @Nonnull final String emoji, @Nullable final String before,
-                                                      @Nullable final String after, @Nonnegative final int limit) {
+    private CompletionStage<JsonArray> getReactionsRaw(@Nonnull final String channelId, @Nonnull final String messageId,
+                                                       @Nonnull final String emoji, @Nullable final String before,
+                                                       @Nullable final String after, @Nonnegative final int limit) {
         final Collection<String> params = new ArrayList<>();
-        if (limit > 0) {
+        if(limit > 0) {
             params.add("limit=" + limit);
         }
-        if (before != null) {
+        if(before != null) {
             params.add("before=" + before);
         }
-        if (after != null) {
+        if(after != null) {
             params.add("after=" + after);
         }
         String query = String.join("&", params);
-        if (!query.isEmpty()) {
+        if(!query.isEmpty()) {
             query = '?' + query;
         }
         return getCatnip().requester()
@@ -237,9 +236,9 @@ public class RestChannel extends RestHandler {
                 .thenApply(ResponsePayload::array);
     }
     
-    public CompletableFuture<List<User>> getReactions(@Nonnull final String channelId, @Nonnull final String messageId,
-                                                        @Nonnull final String emoji, @Nullable final String before,
-                                                        @Nullable final String after, @Nonnegative final int limit) {
+    public CompletionStage<List<User>> getReactions(@Nonnull final String channelId, @Nonnull final String messageId,
+                                                    @Nonnull final String emoji, @Nullable final String before,
+                                                    @Nullable final String after, @Nonnegative final int limit) {
         return getReactionsRaw(channelId, messageId, emoji, before, after, limit)
                 .thenApply(mapObjectContents(getEntityBuilder()::createUser))
                 .thenApply(Collections::unmodifiableList);
@@ -247,9 +246,9 @@ public class RestChannel extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<User>> getReactions(@Nonnull final String channelId, @Nonnull final String messageId,
-                                                      @Nonnull final Emoji emoji, @Nullable final String before,
-                                                      @Nullable final String after, @Nonnegative final int limit) {
+    public CompletionStage<List<User>> getReactions(@Nonnull final String channelId, @Nonnull final String messageId,
+                                                    @Nonnull final Emoji emoji, @Nullable final String before,
+                                                    @Nullable final String after, @Nonnegative final int limit) {
         return getReactions(channelId, messageId, emoji.forReaction(), before, after, limit);
     }
     
@@ -271,9 +270,9 @@ public class RestChannel extends RestHandler {
     //keeping this private for consistency with the rest of the methods
     @Nonnull
     @CheckReturnValue
-    private CompletableFuture<JsonArray> getChannelMessagesRaw(@Nonnull final String channelId, @Nullable final String before,
-                                                               @Nullable final String after, @Nullable final String around,
-                                                               @Nonnegative final int limit) {
+    private CompletionStage<JsonArray> getChannelMessagesRaw(@Nonnull final String channelId, @Nullable final String before,
+                                                             @Nullable final String after, @Nullable final String around,
+                                                             @Nonnegative final int limit) {
         final Collection<String> params = new ArrayList<>();
         if(limit > 0) {
             params.add("limit=" + limit);
@@ -306,7 +305,7 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> triggerTypingIndicator(@Nonnull final String channelId) {
+    public CompletionStage<Void> triggerTypingIndicator(@Nonnull final String channelId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.TRIGGER_TYPING_INDICATOR.withMajorParam(channelId),
                 ImmutableMap.of(), null))
                 .thenApply(__ -> null);
@@ -314,7 +313,7 @@ public class RestChannel extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Channel> getChannelById(@Nonnull final String channelId) {
+    public CompletionStage<Channel> getChannelById(@Nonnull final String channelId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_CHANNEL.withMajorParam(channelId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
@@ -323,7 +322,7 @@ public class RestChannel extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Channel> deleteChannel(@Nonnull final String channelId) {
+    public CompletionStage<Channel> deleteChannel(@Nonnull final String channelId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_CHANNEL.withMajorParam(channelId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
@@ -332,7 +331,8 @@ public class RestChannel extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<CreatedInvite> createInvite(@Nonnull final String channelId, @Nullable final InviteCreateOptions options) {
+    public CompletionStage<CreatedInvite> createInvite(@Nonnull final String channelId,
+                                                       @Nullable final InviteCreateOptions options) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.CREATE_CHANNEL_INVITE.withMajorParam(channelId),
                 ImmutableMap.of(), (options == null ? InviteCreateOptions.create() : options).toJson()))
                 .thenApply(ResponsePayload::object)
@@ -341,7 +341,7 @@ public class RestChannel extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<CreatedInvite>> getChannelInvites(@Nonnull final String channelId) {
+    public CompletionStage<List<CreatedInvite>> getChannelInvites(@Nonnull final String channelId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_CHANNEL_INVITES.withMajorParam(channelId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
@@ -349,7 +349,8 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<GuildChannel> modifyChannel(@Nonnull final String channelId, @Nonnull final ChannelEditFields fields) {
+    public CompletionStage<GuildChannel> modifyChannel(@Nonnull final String channelId,
+                                                       @Nonnull final ChannelEditFields fields) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.MODIFY_CHANNEL.withMajorParam(channelId),
                 ImmutableMap.of(), fields.payload()))
                 .thenApply(ResponsePayload::object)
@@ -357,21 +358,22 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> deletePermissionOverride(@Nonnull final String channelId, @Nonnull final String overwriteId) {
+    public CompletionStage<Void> deletePermissionOverride(@Nonnull final String channelId, @Nonnull final String overwriteId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_CHANNEL_PERMISSION.withMajorParam(channelId),
                 ImmutableMap.of("overwrite.id", overwriteId), null))
                 .thenApply(__ -> null);
     }
     
     @Nonnull
-    public CompletableFuture<Void> deletePermissionOverride(@Nonnull final String channelId, @Nonnull final PermissionOverride overwrite) {
+    public CompletionStage<Void> deletePermissionOverride(@Nonnull final String channelId,
+                                                          @Nonnull final PermissionOverride overwrite) {
         return deletePermissionOverride(channelId, overwrite.id());
     }
     
     @Nonnull
-    public CompletableFuture<Void> editPermissionOverride(@Nonnull final String channelId, @Nonnull final String overwriteId,
-                                                          @Nonnull final Collection<Permission> allowed,
-                                                          @Nonnull final Collection<Permission> denied, final boolean isMember) {
+    public CompletionStage<Void> editPermissionOverride(@Nonnull final String channelId, @Nonnull final String overwriteId,
+                                                        @Nonnull final Collection<Permission> allowed,
+                                                        @Nonnull final Collection<Permission> denied, final boolean isMember) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.EDIT_CHANNEL_PERMISSIONS.withMajorParam(channelId),
                 ImmutableMap.of("overwrite.id", overwriteId), new JsonObject()
                 .put("allow", Permission.from(allowed))
@@ -381,15 +383,15 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> editPermissionOverride(@Nonnull final String channelId, @Nonnull final PermissionOverride overwrite,
-                                                          @Nonnull final Collection<Permission> allowed,
-                                                          @Nonnull final Collection<Permission> denied) {
+    public CompletionStage<Void> editPermissionOverride(@Nonnull final String channelId, @Nonnull final PermissionOverride overwrite,
+                                                        @Nonnull final Collection<Permission> allowed,
+                                                        @Nonnull final Collection<Permission> denied) {
         return editPermissionOverride(channelId, overwrite.id(), allowed, denied, overwrite.type() == OverrideType.MEMBER);
     }
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<Message>> getPinnedMessages(@Nonnull final String channelId) {
+    public CompletionStage<List<Message>> getPinnedMessages(@Nonnull final String channelId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_PINNED_MESSAGES.withMajorParam(channelId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
@@ -397,31 +399,32 @@ public class RestChannel extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> deletePinnedMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
+    public CompletionStage<Void> deletePinnedMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_PINNED_CHANNEL_MESSAGE.withMajorParam(channelId),
                 ImmutableMap.of("message.id", messageId), null))
                 .thenApply(__ -> null);
     }
     
     @Nonnull
-    public CompletableFuture<Void> deletePinnedMessage(@Nonnull final Message message) {
+    public CompletionStage<Void> deletePinnedMessage(@Nonnull final Message message) {
         return deletePinnedMessage(message.channelId(), message.id());
     }
     
     @Nonnull
-    public CompletableFuture<Void> addPinnedMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
+    public CompletionStage<Void> addPinnedMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.ADD_PINNED_CHANNEL_MESSAGE.withMajorParam(channelId),
                 ImmutableMap.of("message.id", messageId), new JsonObject()))
                 .thenApply(__ -> null);
     }
     
     @Nonnull
-    public CompletableFuture<Void> addPinnedMessage(@Nonnull final Message message) {
+    public CompletionStage<Void> addPinnedMessage(@Nonnull final Message message) {
         return addPinnedMessage(message.channelId(), message.id());
     }
     
     @Nonnull
-    public CompletableFuture<Webhook> createWebhook(@Nonnull final String channelId, @Nonnull final String name, @Nullable final String avatar) {
+    public CompletionStage<Webhook> createWebhook(@Nonnull final String channelId, @Nonnull final String name,
+                                                  @Nullable final String avatar) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.CREATE_WEBHOOK.withMajorParam(channelId),
                 ImmutableMap.of(), new JsonObject().put("name", name).put("avatar", avatar)))
                 .thenApply(ResponsePayload::object)

--- a/src/main/java/com/mewna/catnip/rest/handler/RestEmoji.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestEmoji.java
@@ -12,11 +12,10 @@ import io.vertx.core.json.JsonObject;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author natanbc
@@ -28,7 +27,7 @@ public class RestEmoji extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<List<CustomEmoji>> listGuildEmojis(@Nonnull final String guildId) {
+    public CompletionStage<List<CustomEmoji>> listGuildEmojis(@Nonnull final String guildId) {
         return getCatnip().requester().queue(
                 new OutboundRequest(
                         Routes.LIST_GUILD_EMOJIS.withMajorParam(guildId),
@@ -40,7 +39,7 @@ public class RestEmoji extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<CustomEmoji> getGuildEmoji(@Nonnull final String guildId, @Nonnull final String emojiId) {
+    public CompletionStage<CustomEmoji> getGuildEmoji(@Nonnull final String guildId, @Nonnull final String emojiId) {
         return getCatnip().requester().queue(
                 new OutboundRequest(
                         Routes.GET_GUILD_EMOJI.withMajorParam(guildId),
@@ -51,8 +50,8 @@ public class RestEmoji extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<CustomEmoji> createGuildEmoji(@Nonnull final String guildId, @Nonnull final String name,
-                                                           @Nonnull final URI imageData, @Nonnull final Collection<String> roles) {
+    public CompletionStage<CustomEmoji> createGuildEmoji(@Nonnull final String guildId, @Nonnull final String name,
+                                                         @Nonnull final URI imageData, @Nonnull final Collection<String> roles) {
         Utils.validateImageUri(imageData);
         final JsonArray rolesArray;
         if(roles.isEmpty()) {
@@ -76,14 +75,14 @@ public class RestEmoji extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<CustomEmoji> createGuildEmoji(@Nonnull final String guildId, @Nonnull final String name,
-                                                           @Nonnull final byte[] image, @Nonnull final Collection<String> roles) {
+    public CompletionStage<CustomEmoji> createGuildEmoji(@Nonnull final String guildId, @Nonnull final String name,
+                                                         @Nonnull final byte[] image, @Nonnull final Collection<String> roles) {
         return createGuildEmoji(guildId, name, Utils.asImageDataUri(image), roles);
     }
     
     @Nonnull
-    public CompletableFuture<CustomEmoji> modifyGuildEmoji(@Nonnull final String guildId, @Nonnull final String emojiId,
-                                                           @Nonnull final String name, @Nonnull final Collection<String> roles) {
+    public CompletionStage<CustomEmoji> modifyGuildEmoji(@Nonnull final String guildId, @Nonnull final String emojiId,
+                                                         @Nonnull final String name, @Nonnull final Collection<String> roles) {
         final JsonArray rolesArray;
         if(roles.isEmpty()) {
             rolesArray = null;
@@ -105,7 +104,7 @@ public class RestEmoji extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> deleteGuildEmoji(@Nonnull final String guildId, @Nonnull final String emojiId) {
+    public CompletionStage<Void> deleteGuildEmoji(@Nonnull final String guildId, @Nonnull final String emojiId) {
         return getCatnip().requester().queue(
                 new OutboundRequest(
                         Routes.DELETE_GUILD_EMOJI.withMajorParam(guildId),

--- a/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
@@ -25,8 +25,10 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -41,7 +43,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<Role>> getGuildRoles(@Nonnull final String guildId) {
+    public CompletionStage<List<Role>> getGuildRoles(@Nonnull final String guildId) {
         return getCatnip().requester()
                 .queue(new OutboundRequest(Routes.GET_GUILD_ROLES.withMajorParam(guildId),
                         ImmutableMap.of(), null))
@@ -52,7 +54,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Guild> getGuild(@Nonnull final String guildId) {
+    public CompletionStage<Guild> getGuild(@Nonnull final String guildId) {
         return getCatnip().requester()
                 .queue(new OutboundRequest(Routes.GET_GUILD.withMajorParam(guildId),
                         ImmutableMap.of(), null))
@@ -62,7 +64,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Guild> createGuild(@Nonnull final GuildData guild) {
+    public CompletionStage<Guild> createGuild(@Nonnull final GuildData guild) {
         return getCatnip().requester()
                 .queue(new OutboundRequest(Routes.CREATE_GUILD,
                         ImmutableMap.of(), guild.toJson()))
@@ -71,7 +73,7 @@ public class RestGuild extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> deleteGuild(@Nonnull final String guildId) {
+    public CompletionStage<Void> deleteGuild(@Nonnull final String guildId) {
         return getCatnip().requester()
                 .queue(new OutboundRequest(Routes.DELETE_GUILD.withMajorParam(guildId),
                         ImmutableMap.of(), null))
@@ -80,7 +82,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<GuildChannel>> getGuildChannels(@Nonnull final String guildId) {
+    public CompletionStage<List<GuildChannel>> getGuildChannels(@Nonnull final String guildId) {
         return getCatnip().requester()
                 .queue(new OutboundRequest(Routes.GET_GUILD_CHANNELS.withMajorParam(guildId),
                         ImmutableMap.of(), null))
@@ -93,7 +95,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<CreatedInvite>> getGuildInvites(@Nonnull final String guildId) {
+    public CompletionStage<List<CreatedInvite>> getGuildInvites(@Nonnull final String guildId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_INVITES.withMajorParam(guildId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
@@ -101,7 +103,7 @@ public class RestGuild extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Guild> modifyGuild(@Nonnull final String guildId, @Nonnull final GuildEditFields fields) {
+    public CompletionStage<Guild> modifyGuild(@Nonnull final String guildId, @Nonnull final GuildEditFields fields) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.MODIFY_GUILD.withMajorParam(guildId),
                 ImmutableMap.of(), fields.payload()))
                 .thenApply(ResponsePayload::object)
@@ -122,8 +124,8 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<Member>> listGuildMembers(@Nonnull final String guildId, @Nonnegative final int limit,
-                                                            @Nullable final String after) {
+    public CompletionStage<List<Member>> listGuildMembers(@Nonnull final String guildId, @Nonnegative final int limit,
+                                                          @Nullable final String after) {
         return listGuildMembersRaw(guildId, limit, after)
                 .thenApply(mapObjectContents(o -> getEntityBuilder().createMember(guildId, o)));
     }
@@ -132,8 +134,8 @@ public class RestGuild extends RestHandler {
     //keeping this private for consistency with the rest of the methods
     @Nonnull
     @CheckReturnValue
-    private CompletableFuture<JsonArray> listGuildMembersRaw(@Nonnull final String guildId, @Nonnegative final int limit,
-                                                             @Nullable final String after) {
+    private CompletionStage<JsonArray> listGuildMembersRaw(@Nonnull final String guildId, @Nonnegative final int limit,
+                                                           @Nullable final String after) {
         final Collection<String> params = new ArrayList<>();
         if(limit > 0) {
             params.add("limit=" + limit);
@@ -152,7 +154,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<GuildBan>> getGuildBans(@Nonnull final String guildId) {
+    public CompletionStage<List<GuildBan>> getGuildBans(@Nonnull final String guildId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_BANS.withMajorParam(guildId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
@@ -161,7 +163,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<GuildBan> getGuildBan(@Nonnull final String guildId, @Nonnull final String userId) {
+    public CompletionStage<GuildBan> getGuildBan(@Nonnull final String guildId, @Nonnull final String userId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_BAN.withMajorParam(guildId),
                 ImmutableMap.of("user.id", userId), null))
                 .thenApply(ResponsePayload::object)
@@ -169,9 +171,9 @@ public class RestGuild extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> createGuildBan(@Nonnull final String guildId, @Nonnull final String userId,
-                                                  @Nullable final String reason,
-                                                  @Nonnegative final int deleteMessageDays) {
+    public CompletionStage<Void> createGuildBan(@Nonnull final String guildId, @Nonnull final String userId,
+                                                @Nullable final String reason,
+                                                @Nonnegative final int deleteMessageDays) {
         final Collection<String> params = new ArrayList<>();
         if(deleteMessageDays <= 7) {
             params.add("delete-message-days=" + deleteMessageDays);
@@ -189,21 +191,21 @@ public class RestGuild extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> removeGuildBan(@Nonnull final String guildId, @Nonnull final String userId) {
+    public CompletionStage<Void> removeGuildBan(@Nonnull final String guildId, @Nonnull final String userId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_BAN.withMajorParam(guildId),
                 ImmutableMap.of("user.id", userId), null))
                 .thenApply(e -> null);
     }
     
     @Nonnull
-    public CompletableFuture<String> modifyCurrentUsersNick(@Nonnull final String guildId, @Nullable final String nick) {
+    public CompletionStage<String> modifyCurrentUsersNick(@Nonnull final String guildId, @Nullable final String nick) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.MODIFY_CURRENT_USERS_NICK.withQueryString(guildId),
                 ImmutableMap.of(), new JsonObject().put("nick", nick)))
                 .thenApply(ResponsePayload::string);
     }
     
     @Nonnull
-    public CompletableFuture<Void> removeGuildMember(@Nonnull final String guildId, @Nonnull final String userId) {
+    public CompletionStage<Void> removeGuildMember(@Nonnull final String guildId, @Nonnull final String userId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.REMOVE_GUILD_MEMBER.withMajorParam(guildId),
                 ImmutableMap.of("user.id", userId), null))
                 .thenApply(e -> null);
@@ -211,7 +213,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Member> getGuildMember(@Nonnull final String guildId, @Nonnull final String userId) {
+    public CompletionStage<Member> getGuildMember(@Nonnull final String guildId, @Nonnull final String userId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_MEMBER.withMajorParam(guildId),
                 ImmutableMap.of("user.id", userId), null))
                 .thenApply(ResponsePayload::object)
@@ -219,16 +221,16 @@ public class RestGuild extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> removeGuildMemberRole(@Nonnull final String guildId, @Nonnull final String userId,
-                                                         @Nonnull final String roleId) {
+    public CompletionStage<Void> removeGuildMemberRole(@Nonnull final String guildId, @Nonnull final String userId,
+                                                       @Nonnull final String roleId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.REMOVE_GUILD_MEMBER_ROLE.withMajorParam(guildId),
                 ImmutableMap.of("user.id", userId, "role.id", roleId), null))
                 .thenApply(e -> null);
     }
     
     @Nonnull
-    public CompletableFuture<Void> addGuildMemberRole(@Nonnull final String guildId, @Nonnull final String userId,
-                                                      @Nonnull final String roleId) {
+    public CompletionStage<Void> addGuildMemberRole(@Nonnull final String guildId, @Nonnull final String userId,
+                                                    @Nonnull final String roleId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.ADD_GUILD_MEMBER_ROLE.withMajorParam(guildId),
                 ImmutableMap.of("user.id", userId, "role.id", roleId), null))
                 .thenApply(e -> null);
@@ -236,7 +238,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Integer> getGuildPruneCount(@Nonnull final String guildId, @Nonnegative final int days) {
+    public CompletionStage<Integer> getGuildPruneCount(@Nonnull final String guildId, @Nonnegative final int days) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_PRUNE_COUNT.withMajorParam(guildId).withQueryString("?days=" + days),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
@@ -245,7 +247,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Integer> beginGuildPrune(@Nonnull final String guildId, @Nonnegative final int days) {
+    public CompletionStage<Integer> beginGuildPrune(@Nonnull final String guildId, @Nonnegative final int days) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.BEGIN_GUILD_PRUNE.withMajorParam(guildId).withQueryString("?days=" + days),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
@@ -254,7 +256,7 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<VoiceRegion>> getGuildVoiceRegions(@Nonnull final String guildId) {
+    public CompletionStage<List<VoiceRegion>> getGuildVoiceRegions(@Nonnull final String guildId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_VOICE_REGIONS.withQueryString(guildId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
@@ -275,9 +277,9 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<AuditLogEntry>> getGuildAuditLog(@Nonnull final String guildId, @Nullable final String userId,
-                                                              @Nullable final String beforeEntryId, @Nullable final ActionType type,
-                                                              @Nonnegative final int limit) {
+    public CompletionStage<List<AuditLogEntry>> getGuildAuditLog(@Nonnull final String guildId, @Nullable final String userId,
+                                                                 @Nullable final String beforeEntryId, @Nullable final ActionType type,
+                                                                 @Nonnegative final int limit) {
         return getGuildAuditLogRaw(guildId, userId, beforeEntryId, type, limit)
                 .thenApply(getEntityBuilder()::createAuditLog);
     }
@@ -286,24 +288,24 @@ public class RestGuild extends RestHandler {
     //keeping this private for consistency with the rest of the methods
     @Nonnull
     @CheckReturnValue
-    private CompletableFuture<JsonObject> getGuildAuditLogRaw(@Nonnull final String guildId, @Nullable final String userId,
-                                                         @Nullable final String beforeEntryId, @Nullable final ActionType type,
-                                                         @Nonnegative final int limit) {
+    private CompletionStage<JsonObject> getGuildAuditLogRaw(@Nonnull final String guildId, @Nullable final String userId,
+                                                            @Nullable final String beforeEntryId, @Nullable final ActionType type,
+                                                            @Nonnegative final int limit) {
         final Collection<String> params = new ArrayList<>();
-        if (userId != null) {
+        if(userId != null) {
             params.add("user_id=" + userId);
         }
-        if (beforeEntryId != null) {
+        if(beforeEntryId != null) {
             params.add("before=" + beforeEntryId);
         }
-        if (limit <= 100) {
+        if(limit <= 100) {
             params.add("limit=" + limit);
         }
-        if (type != null) {
+        if(type != null) {
             params.add("action_type=" + type);
         }
         String query = String.join("&", params);
-        if (!query.isEmpty()) {
+        if(!query.isEmpty()) {
             query = '?' + query;
         }
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_AUDIT_LOG.withMajorParam(guildId).withQueryString(query),

--- a/src/main/java/com/mewna/catnip/rest/handler/RestInvite.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestInvite.java
@@ -9,7 +9,7 @@ import com.mewna.catnip.rest.Routes;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author natanbc
@@ -22,7 +22,7 @@ public class RestInvite extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Invite> getInvite(@Nonnull final String code) {
+    public CompletionStage<Invite> getInvite(@Nonnull final String code) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_INVITE,
                 ImmutableMap.of("invite.code", code), null))
                 .thenApply(ResponsePayload::object)
@@ -31,7 +31,7 @@ public class RestInvite extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Invite> deleteInvite(@Nonnull final String code) {
+    public CompletionStage<Invite> deleteInvite(@Nonnull final String code) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_INVITE,
                 ImmutableMap.of("invite.code", code), null))
                 .thenApply(ResponsePayload::object)

--- a/src/main/java/com/mewna/catnip/rest/handler/RestUser.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestUser.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -36,7 +35,7 @@ public class RestUser extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<User> getCurrentUser() {
+    public CompletionStage<User> getCurrentUser() {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_CURRENT_USER,
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
@@ -45,7 +44,7 @@ public class RestUser extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<User> getUser(@Nonnull final String userId) {
+    public CompletionStage<User> getUser(@Nonnull final String userId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_USER,
                 ImmutableMap.of("user.id", userId), null))
                 .thenApply(ResponsePayload::object)
@@ -53,7 +52,7 @@ public class RestUser extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<User> modifyCurrentUser(@Nullable final String username, @Nullable final URI avatarData) {
+    public CompletionStage<User> modifyCurrentUser(@Nullable final String username, @Nullable final URI avatarData) {
         final JsonObject body = new JsonObject();
         if(avatarData != null) {
             Utils.validateImageUri(avatarData);
@@ -67,7 +66,7 @@ public class RestUser extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<User> modifyCurrentUser(@Nullable final String username, @Nullable final byte[] avatar) {
+    public CompletionStage<User> modifyCurrentUser(@Nullable final String username, @Nullable final byte[] avatar) {
         return modifyCurrentUser(username, avatar == null ? null : Utils.asImageDataUri(avatar));
     }
     
@@ -85,8 +84,8 @@ public class RestUser extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<PartialGuild>> getCurrentUserGuilds(@Nullable final String before, @Nullable final String after,
-                                                                      @Nonnegative final int limit) {
+    public CompletionStage<List<PartialGuild>> getCurrentUserGuilds(@Nullable final String before, @Nullable final String after,
+                                                                    @Nonnegative final int limit) {
         return getCurrentUserGuildsRaw(before, after, limit)
                 .thenApply(mapObjectContents(getEntityBuilder()::createPartialGuild));
     }
@@ -95,20 +94,20 @@ public class RestUser extends RestHandler {
     //keeping this private for consistency with the rest of the methods
     @Nonnull
     @CheckReturnValue
-    private CompletableFuture<JsonArray> getCurrentUserGuildsRaw(@Nullable final String before, @Nullable final String after,
-                                                                 @Nonnegative final int limit) {
+    private CompletionStage<JsonArray> getCurrentUserGuildsRaw(@Nullable final String before, @Nullable final String after,
+                                                               @Nonnegative final int limit) {
         final Collection<String> params = new ArrayList<>();
-        if (before != null) {
+        if(before != null) {
             params.add("before=" + before);
         }
-        if (after != null) {
+        if(after != null) {
             params.add("before=" + after);
         }
-        if (limit <= 100) {
+        if(limit <= 100) {
             params.add("limit=" + limit);
         }
         String query = String.join("&", params);
-        if (!query.isEmpty()) {
+        if(!query.isEmpty()) {
             query = '?' + query;
         }
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_CURRENT_USER_GUILDS.withQueryString(query),
@@ -118,7 +117,7 @@ public class RestUser extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<DMChannel> createDM(@Nonnull final String recipientId) {
+    public CompletionStage<DMChannel> createDM(@Nonnull final String recipientId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.CREATE_DM,
                 ImmutableMap.of(), new JsonObject().put("recipient_id", recipientId)))
                 .thenApply(ResponsePayload::object)
@@ -126,7 +125,7 @@ public class RestUser extends RestHandler {
     }
     
     @Nonnull
-    public CompletableFuture<Void> leaveGuild(@Nonnull final String guildId) {
+    public CompletionStage<Void> leaveGuild(@Nonnull final String guildId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.LEAVE_GUILD.withMajorParam(guildId),
                 ImmutableMap.of(), null))
                 .thenApply(__ -> null);

--- a/src/main/java/com/mewna/catnip/rest/handler/RestVoice.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestVoice.java
@@ -10,7 +10,7 @@ import com.mewna.catnip.rest.Routes;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public class RestVoice extends RestHandler {
     public RestVoice(final CatnipImpl catnip) {
@@ -19,7 +19,7 @@ public class RestVoice extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<VoiceRegion>> listVoiceRegions() {
+    public CompletionStage<List<VoiceRegion>> listVoiceRegions() {
         return getCatnip().requester().queue(new OutboundRequest(Routes.LIST_VOICE_REGIONS,
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)

--- a/src/main/java/com/mewna/catnip/rest/handler/RestWebhook.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestWebhook.java
@@ -11,7 +11,7 @@ import com.mewna.catnip.rest.Routes;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * @author natanbc
@@ -24,7 +24,7 @@ public class RestWebhook extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Webhook> getWebhook(@Nonnull final String webhookId) {
+    public CompletionStage<Webhook> getWebhook(@Nonnull final String webhookId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_WEBHOOK.withMajorParam(webhookId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::object)
@@ -33,7 +33,7 @@ public class RestWebhook extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<Webhook>> getGuildWebhooks(@Nonnull final String guildId) {
+    public CompletionStage<List<Webhook>> getGuildWebhooks(@Nonnull final String guildId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_WEBHOOKS.withMajorParam(guildId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
@@ -42,7 +42,7 @@ public class RestWebhook extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<List<Webhook>> getChannelWebhooks(@Nonnull final String channelId) {
+    public CompletionStage<List<Webhook>> getChannelWebhooks(@Nonnull final String channelId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.GET_CHANNEL_WEBHOOKS.withMajorParam(channelId),
                 ImmutableMap.of(), null))
                 .thenApply(ResponsePayload::array)
@@ -51,7 +51,7 @@ public class RestWebhook extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Webhook> modifyWebhook(@Nonnull final String webhookId, @Nonnull final WebhookEditFields fields) {
+    public CompletionStage<Webhook> modifyWebhook(@Nonnull final String webhookId, @Nonnull final WebhookEditFields fields) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.MODIFY_WEBHOOK.withMajorParam(webhookId),
                 ImmutableMap.of(), fields.payload()))
                 .thenApply(ResponsePayload::object)
@@ -60,7 +60,7 @@ public class RestWebhook extends RestHandler {
     
     @Nonnull
     @CheckReturnValue
-    public CompletableFuture<Void> deleteWebhook(@Nonnull final String webhookId) {
+    public CompletionStage<Void> deleteWebhook(@Nonnull final String webhookId) {
         return getCatnip().requester().queue(new OutboundRequest(Routes.DELETE_WEBHOOK.withMajorParam(webhookId),
                 ImmutableMap.of(), null))
                 .thenApply(__ -> null);

--- a/src/main/java/com/mewna/catnip/util/pagination/BasePaginator.java
+++ b/src/main/java/com/mewna/catnip/util/pagination/BasePaginator.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
  * @author natanbc
  * @since 10/8/18.
  */
+@SuppressWarnings("unused")
 public abstract class BasePaginator<T, J, P extends BasePaginator<T, J, P>> {
     protected final Function<T, String> idOf;
     protected final int maxRequestSize;
@@ -33,6 +34,13 @@ public abstract class BasePaginator<T, J, P extends BasePaginator<T, J, P>> {
         this.idOf = idOf;
         this.maxRequestSize = maxRequestSize;
         requestSize = maxRequestSize;
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    @SuppressWarnings("unchecked")
+    private static <T, J, P extends BasePaginator<T, J, P>> P uncheck(@Nonnull final BasePaginator<?, ?, ?> paginator) {
+        return (P) paginator;
     }
     
     /**
@@ -151,13 +159,6 @@ public abstract class BasePaginator<T, J, P extends BasePaginator<T, J, P>> {
     protected abstract CompletionStage<J> fetchNext(@Nonnull RequestState<T> state, @Nullable String lastId,
                                                     @Nonnegative int requestSize);
     
-    @Nonnull
-    @CheckReturnValue
-    @SuppressWarnings("unchecked")
-    private static <T, J, P extends BasePaginator<T, J, P>> P uncheck(@Nonnull final BasePaginator<?, ?, ?> paginator) {
-        return (P)paginator;
-    }
-    
     protected static class RequestState<T> {
         private final Map<String, Object> extras = new HashMap<>();
         private final int limit;
@@ -166,7 +167,7 @@ public abstract class BasePaginator<T, J, P extends BasePaginator<T, J, P>> {
         private int fetched;
         private T last;
         private boolean callbackDone;
-    
+        
         public RequestState(final int limit, final int requestSize, final PaginationCallback<T> callback) {
             this.limit = limit;
             this.requestSize = requestSize;
@@ -181,17 +182,17 @@ public abstract class BasePaginator<T, J, P extends BasePaginator<T, J, P>> {
             fetched++;
             last = entity;
         }
-    
+        
         @CheckReturnValue
         public boolean done() {
             return callbackDone || limit > 0 && fetched == limit;
         }
-    
+        
         @CheckReturnValue
         public int entitiesToFetch() {
             return Math.min(requestSize, remaining());
         }
-    
+        
         @CheckReturnValue
         public int remaining() {
             return limit - fetched;
@@ -213,7 +214,7 @@ public abstract class BasePaginator<T, J, P extends BasePaginator<T, J, P>> {
         @CheckReturnValue
         @SuppressWarnings("unchecked")
         public <U> U extra(@Nonnull final String key) {
-            return (U)extras.get(key);
+            return (U) extras.get(key);
         }
     }
 }


### PR DESCRIPTION
This is a *breaking* change, mainly because it removes the ability to use things like `#get()`. We still use CompletableFuture<T>s internally; it's just the external API that changed. 