### PR TITLE
extra functions for cache views + tests

### DIFF
--- a/src/main/java/com/mewna/catnip/cache/view/EmptyCacheView.java
+++ b/src/main/java/com/mewna/catnip/cache/view/EmptyCacheView.java
@@ -28,12 +28,9 @@
 package com.mewna.catnip.cache.view;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.Collector;
 
 /**
  * Always empty {@link CacheView cache view}.
@@ -46,8 +43,18 @@ public class EmptyCacheView<T> implements CacheView<T> {
     public static final CacheView<?> INSTANCE = new EmptyCacheView<>();
     
     @Override
+    public void forEach(final Consumer<? super T> action) {
+    
+    }
+    
+    @Override
     public long size() {
         return 0;
+    }
+    
+    @Override
+    public boolean isEmpty() {
+        return true;
     }
     
     @Override
@@ -56,20 +63,70 @@ public class EmptyCacheView<T> implements CacheView<T> {
     }
     
     @Override
-    public T findAny(@Nonnull final Predicate<T> filter) {
+    public T findAny(@Nonnull final Predicate<? super T> filter) {
         return null;
     }
     
     @Nonnull
     @Override
-    public Collection<T> find(@Nonnull final Predicate<T> filter) {
+    public Collection<T> find(@Nonnull final Predicate<? super T> filter) {
         return Collections.emptyList();
     }
     
     @Nonnull
     @Override
-    public <C extends Collection<T>> C find(@Nonnull final Predicate<T> filter, @Nonnull final Supplier<C> supplier) {
+    public <C extends Collection<T>> C find(@Nonnull final Predicate<? super T> filter, @Nonnull final Supplier<C> supplier) {
         return supplier.get();
+    }
+    
+    @Override
+    public <A, R> R collect(final Collector<? super T, A, R> collector) {
+        return collector.finisher().apply(collector.supplier().get());
+    }
+    
+    @Override
+    public <R> R collect(final Supplier<R> supplier, final BiConsumer<R, ? super T> accumulator, final BiConsumer<R, R> combiner) {
+        return supplier.get();
+    }
+    
+    @Override
+    public <U> U reduce(final U identity, final BiFunction<U, ? super T, U> accumulator, final BinaryOperator<U> combiner) {
+        return identity;
+    }
+    
+    @Override
+    public Optional<T> reduce(final BinaryOperator<T> accumulator) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public T reduce(final T identity, final BinaryOperator<T> accumulator) {
+        return identity;
+    }
+    
+    @Override
+    public boolean anyMatch(final Predicate<? super T> predicate) {
+        return false;
+    }
+    
+    @Override
+    public boolean allMatch(final Predicate<? super T> predicate) {
+        return true;
+    }
+    
+    @Override
+    public boolean noneMatch(final Predicate<? super T> predicate) {
+        return true;
+    }
+    
+    @Override
+    public Optional<T> min(final Comparator<? super T> comparator) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public Optional<T> max(final Comparator<? super T> comparator) {
+        return Optional.empty();
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/cache/view/NamedCacheView.java
+++ b/src/main/java/com/mewna/catnip/cache/view/NamedCacheView.java
@@ -57,6 +57,9 @@ public interface NamedCacheView<T> extends CacheView<T> {
      *
      * @see String#equals(Object)
      * @see String#equalsIgnoreCase(String)
+     *
+     * @implNote Implementations should attempt to perform this operation without
+     *           copying the elements of this view whenever possible.
      */
     @Nonnull
     Collection<T> findByName(@Nonnull String name, boolean ignoreCase);
@@ -69,6 +72,9 @@ public interface NamedCacheView<T> extends CacheView<T> {
      * @return All elements that have a name equal to the provided.
      *
      * @see String#equals(Object)
+     *
+     * @implNote Implementations should attempt to perform this operation without
+     *           copying the elements of this view whenever possible.
      */
     @Nonnull
     default Collection<T> findByName(@Nonnull final String name) {
@@ -86,6 +92,9 @@ public interface NamedCacheView<T> extends CacheView<T> {
      *
      * @see String#contains(CharSequence)
      * @see com.mewna.catnip.util.Utils#containsIgnoreCase(String, String)
+     *
+     * @implNote Implementations should attempt to perform this operation without
+     *           copying the elements of this view whenever possible.
      */
     @Nonnull
     Collection<T> findByNameContains(@Nonnull final String name, boolean ignoreCase);
@@ -98,6 +107,9 @@ public interface NamedCacheView<T> extends CacheView<T> {
      * @return All elements that have a name containing the provided.
      *
      * @see String#contains(CharSequence)
+     *
+     * @implNote Implementations should attempt to perform this operation without
+     *           copying the elements of this view whenever possible.
      */
     @Nonnull
     default Collection<T> findByNameContains(@Nonnull final String name) {
@@ -115,6 +127,9 @@ public interface NamedCacheView<T> extends CacheView<T> {
      *
      * @see String#startsWith(String)
      * @see com.mewna.catnip.util.Utils#startsWithIgnoreCase(String, String)
+     *
+     * @implNote Implementations should attempt to perform this operation without
+     *           copying the elements of this view whenever possible.
      */
     @Nonnull
     Collection<T> findByNameStartsWith(@Nonnull final String name, boolean ignoreCase);
@@ -127,6 +142,9 @@ public interface NamedCacheView<T> extends CacheView<T> {
      * @return All elements that have a name starting with the provided.
      *
      * @see String#startsWith(String)
+     *
+     * @implNote Implementations should attempt to perform this operation without
+     *           copying the elements of this view whenever possible.
      */
     @Nonnull
     default Collection<T> findByNameStartsWith(@Nonnull final String name) {
@@ -144,6 +162,9 @@ public interface NamedCacheView<T> extends CacheView<T> {
      *
      * @see String#endsWith(String)
      * @see com.mewna.catnip.util.Utils#endsWithIgnoreCase(String, String)
+     *
+     * @implNote Implementations should attempt to perform this operation without
+     *           copying the elements of this view whenever possible.
      */
     @Nonnull
     Collection<T> findByNameEndsWith(@Nonnull final String name, boolean ignoreCase);
@@ -156,6 +177,9 @@ public interface NamedCacheView<T> extends CacheView<T> {
      * @return All elements that have a name ending with the provided.
      *
      * @see String#endsWith(String)
+     *
+     * @implNote Implementations should attempt to perform this operation without
+     *           copying the elements of this view whenever possible.
      */
     @Nonnull
     default Collection<T> findByNameEndsWith(@Nonnull final String name) {

--- a/src/test/java/com/mewna/catnip/cache/view/CompositeCacheViewTests.java
+++ b/src/test/java/com/mewna/catnip/cache/view/CompositeCacheViewTests.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2018 amy, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.mewna.catnip.cache.view;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class CompositeCacheViewTests {
+    @SafeVarargs
+    private static <T> CompositeCacheView<T> composite(final CacheView<T>... views) {
+        return new CompositeCacheView<>(Arrays.asList(views));
+    }
+    
+    @Test
+    public void getById() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        Assertions.assertEquals(composite(cache).getById(123), "some string");
+    }
+    
+    @Test
+    public void size() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        Assertions.assertEquals(composite(cache1, cache2).size(), 2);
+    }
+    
+    @Test
+    public void isEmpty() {
+        Assertions.assertTrue(composite().isEmpty());
+    }
+    
+    @Test
+    public void isNotEmpty() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        Assertions.assertFalse(composite(cache1, cache2).isEmpty());
+    }
+    
+    @Test
+    public void findAny() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        Assertions.assertEquals(composite(cache1, cache2).findAny(__ -> true), "some string");
+    }
+    
+    @Test
+    public void findAnyNoMatches() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        Assertions.assertNull(composite(cache1, cache2).findAny(__ -> false));
+    }
+    
+    @Test
+    public void find() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        Assertions.assertEquals(composite(cache1, cache2).find(__ -> true).size(), 2);
+    }
+    
+    @Test
+    public void findNoMatches() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        Assertions.assertTrue(composite(cache1, cache2).find(__ -> false).isEmpty());
+    }
+    
+    @Test
+    public void collect1() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        final List<String> list = composite(cache1, cache2).collect(Collectors.toList());
+        Assertions.assertEquals(list.size(), 2);
+        Assertions.assertTrue(list.contains("some string"));
+        Assertions.assertTrue(list.contains("some other string"));
+    }
+    
+    @Test
+    public void collect2() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        final List<String> list = composite(cache1, cache2).collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+        Assertions.assertEquals(list.size(), 2);
+        Assertions.assertTrue(list.contains("some string"));
+        Assertions.assertTrue(list.contains("some other string"));
+    }
+    
+    @Test
+    public void reduce1() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        final String s = composite(cache1, cache2).reduce("", String::concat, String::concat);
+        Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
+        Assertions.assertTrue(
+                s.equals("some stringsome other string") ||
+                        s.equals("some other stringsome string")
+        );
+    }
+    
+    @Test
+    public void reduce2() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        final String s = composite(cache1, cache2).reduce("", String::concat);
+        Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
+        Assertions.assertTrue(
+                s.equals("some stringsome other string") ||
+                        s.equals("some other stringsome string")
+        );
+    }
+    
+    @Test
+    public void reduce3Empty() {
+        final Optional<String> maybeS = CompositeCacheViewTests.<String>composite().reduce(String::concat);
+        Assertions.assertFalse(maybeS.isPresent());
+    }
+    
+    @Test
+    public void reduce3() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        final Optional<String> maybeS = composite(cache1, cache2).reduce(String::concat);
+        Assertions.assertTrue(maybeS.isPresent());
+        final String s = maybeS.get();
+        Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
+        Assertions.assertTrue(
+                s.equals("some stringsome other string") ||
+                        s.equals("some other stringsome string")
+        );
+    }
+    
+    @Test
+    public void anyMatch() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        Assertions.assertTrue(composite(cache1, cache2).anyMatch("some string"::equals));
+    }
+    
+    @Test
+    public void anyMatchEmpty() {
+        Assertions.assertFalse(composite().anyMatch("some string"::equals));
+    }
+    
+    @Test
+    public void allMatch() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        Assertions.assertFalse(composite(cache1, cache2).allMatch("some string"::equals));
+    }
+    
+    @Test
+    public void allMatchEmpty() {
+        Assertions.assertTrue(composite().allMatch("some string"::equals));
+    }
+    
+    @Test
+    public void noneMatch() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        Assertions.assertFalse(composite(cache1, cache2).noneMatch("some string"::equals));
+    }
+    
+    @Test
+    public void noneMatchEmpty() {
+        Assertions.assertTrue(composite().noneMatch("some string"::equals));
+    }
+    
+    @Test
+    public void min() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        final Optional<String> min = composite(cache1, cache2).min(Comparator.comparingInt(String::length));
+        Assertions.assertTrue(min.isPresent());
+        Assertions.assertEquals(min.get(), "some string");
+    }
+    
+    @Test
+    public void max() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        cache1.put("123", "some string");
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        cache2.put("456", "some other string");
+        final Optional<String> max = composite(cache1, cache2).max(Comparator.comparingInt(String::length));
+        Assertions.assertTrue(max.isPresent());
+        Assertions.assertEquals(max.get(), "some other string");
+    }
+    
+    @Test
+    public void keys() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        final CompositeCacheView<String> cache = composite(cache1, cache2);
+        Assertions.assertTrue(cache.keys().isEmpty());
+        cache1.put("123", "some string");
+        Assertions.assertEquals(cache.keys().size(), 1);
+        cache2.put("456", "some other string");
+        Assertions.assertEquals(cache.keys().size(), 2);
+        
+        Assertions.assertTrue(cache.keys().contains(123L));
+        Assertions.assertTrue(cache.keys().contains(456L));
+        Assertions.assertFalse(cache.keys().contains(789L));
+    }
+    
+    @Test
+    public void values() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        final CompositeCacheView<String> cache = composite(cache1, cache2);
+        Assertions.assertTrue(cache.values().isEmpty());
+        cache1.put("123", "some string");
+        Assertions.assertEquals(cache.values().size(), 1);
+        cache2.put("456", "some other string");
+        Assertions.assertEquals(cache.values().size(), 2);
+        
+        Assertions.assertTrue(cache.values().contains("some string"));
+        Assertions.assertTrue(cache.values().contains("some other string"));
+        Assertions.assertFalse(cache.values().contains("yet another string"));
+    }
+    
+    @Test
+    public void snapshot() {
+        final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
+        final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
+        final CompositeCacheView<String> cache = composite(cache1, cache2);
+        final Collection<String> snapshot1 = cache.snapshot();
+        Assertions.assertTrue(cache.values().isEmpty());
+        cache1.put("123", "some string");
+        Assertions.assertTrue(snapshot1.isEmpty());
+        Assertions.assertEquals(cache.values().size(), 1);
+        final Collection<String> snapshot2 = cache.snapshot();
+        cache2.put("456", "some other string");
+        Assertions.assertEquals(cache.values().size(), 2);
+        Assertions.assertEquals(snapshot2.size(), 1);
+        
+        Assertions.assertFalse(snapshot1.contains("some string"));
+        Assertions.assertTrue(snapshot2.contains("some string"));
+        Assertions.assertFalse(snapshot2.contains("yet another string"));
+    }
+}

--- a/src/test/java/com/mewna/catnip/cache/view/DefaultCacheViewTests.java
+++ b/src/test/java/com/mewna/catnip/cache/view/DefaultCacheViewTests.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2018 amy, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.mewna.catnip.cache.view;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class DefaultCacheViewTests {
+    @Test
+    public void getById() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        Assertions.assertEquals(cache.getById(123), "some string");
+    }
+    
+    @Test
+    public void size() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        Assertions.assertEquals(cache.size(), 1);
+    }
+    
+    @Test
+    public void isEmpty() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        Assertions.assertTrue(cache.isEmpty());
+    }
+    
+    @Test
+    public void isNotEmpty() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        Assertions.assertFalse(cache.isEmpty());
+    }
+    
+    @Test
+    public void findAny() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        Assertions.assertEquals(cache.findAny(__ -> true), "some string");
+    }
+    
+    @Test
+    public void findAnyNoMatches() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        Assertions.assertNull(cache.findAny(__ -> false));
+    }
+    
+    @Test
+    public void find() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        Assertions.assertEquals(cache.find(__ -> true).size(), 2);
+    }
+    
+    @Test
+    public void findNoMatches() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        Assertions.assertTrue(cache.find(__ -> false).isEmpty());
+    }
+    
+    @Test
+    public void collect1() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        final List<String> list = cache.collect(Collectors.toList());
+        Assertions.assertEquals(list.size(), 2);
+        Assertions.assertTrue(list.contains("some string"));
+        Assertions.assertTrue(list.contains("some other string"));
+    }
+    
+    @Test
+    public void collect2() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        final List<String> list = cache.collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+        Assertions.assertEquals(list.size(), 2);
+        Assertions.assertTrue(list.contains("some string"));
+        Assertions.assertTrue(list.contains("some other string"));
+    }
+    
+    @Test
+    public void reduce1() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        final String s = cache.reduce("", String::concat, String::concat);
+        Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
+        Assertions.assertTrue(
+                s.equals("some stringsome other string") ||
+                        s.equals("some other stringsome string")
+        );
+    }
+    
+    @Test
+    public void reduce2() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        final String s = cache.reduce("", String::concat);
+        Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
+        Assertions.assertTrue(
+                s.equals("some stringsome other string") ||
+                        s.equals("some other stringsome string")
+        );
+    }
+    
+    @Test
+    public void reduce3Empty() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        final Optional<String> maybeS = cache.reduce(String::concat);
+        Assertions.assertFalse(maybeS.isPresent());
+    }
+    
+    @Test
+    public void reduce3() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        final Optional<String> maybeS = cache.reduce(String::concat);
+        Assertions.assertTrue(maybeS.isPresent());
+        final String s = maybeS.get();
+        Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
+        Assertions.assertTrue(
+                s.equals("some stringsome other string") ||
+                        s.equals("some other stringsome string")
+        );
+    }
+    
+    @Test
+    public void anyMatch() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        Assertions.assertTrue(cache.anyMatch("some string"::equals));
+    }
+    
+    @Test
+    public void anyMatchEmpty() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        Assertions.assertFalse(cache.anyMatch("some string"::equals));
+    }
+    
+    @Test
+    public void allMatch() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        Assertions.assertFalse(cache.allMatch("some string"::equals));
+    }
+    
+    @Test
+    public void allMatchEmpty() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        Assertions.assertTrue(cache.allMatch("some string"::equals));
+    }
+    
+    @Test
+    public void noneMatch() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        Assertions.assertFalse(cache.noneMatch("some string"::equals));
+    }
+    
+    @Test
+    public void noneMatchEmpty() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        Assertions.assertTrue(cache.noneMatch("some string"::equals));
+    }
+    
+    @Test
+    public void min() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        final Optional<String> min = cache.min(Comparator.comparingInt(String::length));
+        Assertions.assertTrue(min.isPresent());
+        Assertions.assertEquals(min.get(), "some string");
+    }
+    
+    @Test
+    public void max() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        cache.put("123", "some string");
+        cache.put("456", "some other string");
+        final Optional<String> max = cache.max(Comparator.comparingInt(String::length));
+        Assertions.assertTrue(max.isPresent());
+        Assertions.assertEquals(max.get(), "some other string");
+    }
+    
+    @Test
+    public void keys() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        Assertions.assertTrue(cache.keys().isEmpty());
+        cache.put("123", "some string");
+        Assertions.assertEquals(cache.keys().size(), 1);
+        cache.put("456", "some other string");
+        Assertions.assertEquals(cache.keys().size(), 2);
+        
+        Assertions.assertTrue(cache.keys().contains(123L));
+        Assertions.assertTrue(cache.keys().contains(456L));
+        Assertions.assertFalse(cache.keys().contains(789L));
+    }
+    
+    @Test
+    public void values() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        Assertions.assertTrue(cache.values().isEmpty());
+        cache.put("123", "some string");
+        Assertions.assertEquals(cache.values().size(), 1);
+        cache.put("456", "some other string");
+        Assertions.assertEquals(cache.values().size(), 2);
+        
+        Assertions.assertTrue(cache.values().contains("some string"));
+        Assertions.assertTrue(cache.values().contains("some other string"));
+        Assertions.assertFalse(cache.values().contains("yet another string"));
+    }
+    
+    @Test
+    public void snapshot() {
+        final DefaultCacheView<String> cache = new DefaultCacheView<>();
+        final Collection<String> snapshot1 = cache.snapshot();
+        Assertions.assertTrue(cache.values().isEmpty());
+        cache.put("123", "some string");
+        Assertions.assertTrue(snapshot1.isEmpty());
+        Assertions.assertEquals(cache.values().size(), 1);
+        final Collection<String> snapshot2 = cache.snapshot();
+        cache.put("456", "some other string");
+        Assertions.assertEquals(cache.values().size(), 2);
+        Assertions.assertEquals(snapshot2.size(), 1);
+    
+        Assertions.assertFalse(snapshot1.contains("some string"));
+        Assertions.assertTrue(snapshot2.contains("some string"));
+        Assertions.assertFalse(snapshot2.contains("yet another string"));
+    }
+}

--- a/src/test/java/com/mewna/catnip/cache/view/DefaultNamedCacheViewTests.java
+++ b/src/test/java/com/mewna/catnip/cache/view/DefaultNamedCacheViewTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2018 amy, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.mewna.catnip.cache.view;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
+
+public class DefaultNamedCacheViewTests {
+    @Test
+    public void findByName() {
+        final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
+        cache.put("123", "string");
+        Assertions.assertFalse(cache.findByName("string").isEmpty());
+        Assertions.assertTrue(cache.findByName("StRiNg").isEmpty());
+    }
+    
+    @Test
+    public void findByNameIgnoreCase() {
+        final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
+        cache.put("123", "string");
+        Assertions.assertFalse(cache.findByName("StRiNg", true).isEmpty());
+    }
+    
+    @Test
+    public void findByNameContains() {
+        final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
+        cache.put("123", "string");
+        Assertions.assertFalse(cache.findByNameContains("tri").isEmpty());
+        Assertions.assertTrue(cache.findByNameContains("tRi").isEmpty());
+    }
+    
+    @Test
+    public void findByNameContainsIgnoreCase() {
+        final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
+        cache.put("123", "string");
+        Assertions.assertFalse(cache.findByNameContains("tRi", true).isEmpty());
+    }
+    
+    @Test
+    public void findByNameStartsWith() {
+        final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
+        cache.put("123", "string");
+        Assertions.assertFalse(cache.findByNameStartsWith("str").isEmpty());
+        Assertions.assertTrue(cache.findByNameStartsWith("StR").isEmpty());
+    }
+    
+    @Test
+    public void findByNameStartsWithIgnoreCase() {
+        final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
+        cache.put("123", "string");
+        Assertions.assertFalse(cache.findByNameStartsWith("StR", true).isEmpty());
+    }
+    
+    @Test
+    public void findByNameEndsWith() {
+        final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
+        cache.put("123", "string");
+        Assertions.assertFalse(cache.findByNameEndsWith("ing").isEmpty());
+        Assertions.assertTrue(cache.findByNameEndsWith("iNg").isEmpty());
+    }
+    
+    @Test
+    public void findByNameEndsWithIgnoreCase() {
+        final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
+        cache.put("123", "string");
+        Assertions.assertFalse(cache.findByNameEndsWith("iNg", true).isEmpty());
+    }
+}


### PR DESCRIPTION
New methods:
- forEach
- isEmpty
- collect
- reduce
- anyMatch
- allMatch
- noneMatch
- min
- max

Fixes:
- mutable iterators/spliterators being returned by cache views