### PR TITLE
cache optimizations

### DIFF
--- a/src/main/java/com/mewna/catnip/cache/view/MutableCacheView.java
+++ b/src/main/java/com/mewna/catnip/cache/view/MutableCacheView.java
@@ -44,6 +44,7 @@ public interface MutableCacheView<T> extends CacheView<T> {
     @Nullable
     T put(long key, @Nonnull T value);
     
+    @Deprecated
     @Nullable
     default T put(@Nonnull final String key, @Nonnull final T value) {
         return put(Long.parseUnsignedLong(key), value);
@@ -52,6 +53,7 @@ public interface MutableCacheView<T> extends CacheView<T> {
     @Nullable
     T remove(final long key);
     
+    @Deprecated
     @Nullable
     default T remove(@Nonnull final String key) {
         return remove(Long.parseUnsignedLong(key));

--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -644,7 +644,7 @@ public final class EntityBuilder {
                 .catnip(catnip)
                 .guildIdAsLong(guildId == null ? 0 : Long.parseUnsignedLong(guildId))
                 .channelIdAsLong(channelId == null ? 0 : Long.parseUnsignedLong(channelId))
-                .userIdAsLong(Long.parseLong(data.getString("user_id")))
+                .userIdAsLong(Long.parseUnsignedLong(data.getString("user_id")))
                 .sessionId(data.getString("session_id"))
                 .deaf(data.getBoolean("deaf"))
                 .mute(data.getBoolean("mute"))
@@ -1135,7 +1135,7 @@ public final class EntityBuilder {
             case CHANNEL_OVERWRITE_DELETE:
                 return OverrideUpdateInfoImpl.builder()
                         .catnip(catnip)
-                        .overriddenEntityIdAsLong(Long.parseLong(data.getString("id")))
+                        .overriddenEntityIdAsLong(Long.parseUnsignedLong(data.getString("id")))
                         .overrideType(OverrideType.byKey(data.getString("type")))
                         .roleName(data.getString("role_name"))
                         .build();

--- a/src/main/java/com/mewna/catnip/entity/message/Message.java
+++ b/src/main/java/com/mewna/catnip/entity/message/Message.java
@@ -205,7 +205,8 @@ public interface Message extends Snowflake {
         if(guild != 0) {
             return (TextChannel) catnip().cache().channel(guild, channelIdAsLong());
         } else {
-            return catnip().cache().dmChannel(channelIdAsLong());
+            //TODO: should we change cache to store by private channel id instead?
+            return catnip().cache().dmChannel(author().idAsLong());
         }
     }
     

--- a/src/test/java/com/mewna/catnip/cache/view/CompositeCacheViewTests.java
+++ b/src/test/java/com/mewna/catnip/cache/view/CompositeCacheViewTests.java
@@ -42,16 +42,16 @@ public class CompositeCacheViewTests {
     @Test
     public void getById() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertEquals(composite(cache).getById(123), "some string");
     }
     
     @Test
     public void size() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertEquals(composite(cache1, cache2).size(), 2);
     }
     
@@ -63,54 +63,54 @@ public class CompositeCacheViewTests {
     @Test
     public void isNotEmpty() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertFalse(composite(cache1, cache2).isEmpty());
     }
     
     @Test
     public void findAny() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertEquals(composite(cache1, cache2).findAny(__ -> true), "some string");
     }
     
     @Test
     public void findAnyNoMatches() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertNull(composite(cache1, cache2).findAny(__ -> false));
     }
     
     @Test
     public void find() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertEquals(composite(cache1, cache2).find(__ -> true).size(), 2);
     }
     
     @Test
     public void findNoMatches() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertTrue(composite(cache1, cache2).find(__ -> false).isEmpty());
     }
     
     @Test
     public void collect1() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         final List<String> list = composite(cache1, cache2).collect(Collectors.toList());
         Assertions.assertEquals(list.size(), 2);
         Assertions.assertTrue(list.contains("some string"));
@@ -120,9 +120,9 @@ public class CompositeCacheViewTests {
     @Test
     public void collect2() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         final List<String> list = composite(cache1, cache2).collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
         Assertions.assertEquals(list.size(), 2);
         Assertions.assertTrue(list.contains("some string"));
@@ -132,9 +132,9 @@ public class CompositeCacheViewTests {
     @Test
     public void reduce1() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         final String s = composite(cache1, cache2).reduce("", String::concat, String::concat);
         Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
         Assertions.assertTrue(
@@ -146,9 +146,9 @@ public class CompositeCacheViewTests {
     @Test
     public void reduce2() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         final String s = composite(cache1, cache2).reduce("", String::concat);
         Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
         Assertions.assertTrue(
@@ -166,9 +166,9 @@ public class CompositeCacheViewTests {
     @Test
     public void reduce3() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         final Optional<String> maybeS = composite(cache1, cache2).reduce(String::concat);
         Assertions.assertTrue(maybeS.isPresent());
         final String s = maybeS.get();
@@ -182,9 +182,9 @@ public class CompositeCacheViewTests {
     @Test
     public void anyMatch() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertTrue(composite(cache1, cache2).anyMatch("some string"::equals));
     }
     
@@ -196,9 +196,9 @@ public class CompositeCacheViewTests {
     @Test
     public void allMatch() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertFalse(composite(cache1, cache2).allMatch("some string"::equals));
     }
     
@@ -210,9 +210,9 @@ public class CompositeCacheViewTests {
     @Test
     public void noneMatch() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertFalse(composite(cache1, cache2).noneMatch("some string"::equals));
     }
     
@@ -224,9 +224,9 @@ public class CompositeCacheViewTests {
     @Test
     public void min() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         final Optional<String> min = composite(cache1, cache2).min(Comparator.comparingInt(String::length));
         Assertions.assertTrue(min.isPresent());
         Assertions.assertEquals(min.get(), "some string");
@@ -235,9 +235,9 @@ public class CompositeCacheViewTests {
     @Test
     public void max() {
         final DefaultCacheView<String> cache1 = new DefaultCacheView<>();
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         final Optional<String> max = composite(cache1, cache2).max(Comparator.comparingInt(String::length));
         Assertions.assertTrue(max.isPresent());
         Assertions.assertEquals(max.get(), "some other string");
@@ -249,9 +249,9 @@ public class CompositeCacheViewTests {
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
         final CompositeCacheView<String> cache = composite(cache1, cache2);
         Assertions.assertTrue(cache.keys().isEmpty());
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         Assertions.assertEquals(cache.keys().size(), 1);
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertEquals(cache.keys().size(), 2);
         
         Assertions.assertTrue(cache.keys().contains(123L));
@@ -265,9 +265,9 @@ public class CompositeCacheViewTests {
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
         final CompositeCacheView<String> cache = composite(cache1, cache2);
         Assertions.assertTrue(cache.values().isEmpty());
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         Assertions.assertEquals(cache.values().size(), 1);
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertEquals(cache.values().size(), 2);
         
         Assertions.assertTrue(cache.values().contains("some string"));
@@ -281,9 +281,9 @@ public class CompositeCacheViewTests {
         final DefaultCacheView<String> cache2 = new DefaultCacheView<>();
         final CompositeCacheView<String> cache = composite(cache1, cache2);
         Assertions.assertEquals(cache.count(__ -> true), 0);
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         Assertions.assertEquals(cache.count(__ -> true), 1);
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertEquals(cache.count(__ -> true), 2);
         Assertions.assertEquals(cache.count("some string"::equals), 1);
         Assertions.assertEquals(cache.count("some other string"::equals), 1);
@@ -297,11 +297,11 @@ public class CompositeCacheViewTests {
         final CompositeCacheView<String> cache = composite(cache1, cache2);
         final Collection<String> snapshot1 = cache.snapshot();
         Assertions.assertTrue(cache.values().isEmpty());
-        cache1.put("123", "some string");
+        cache1.put(123, "some string");
         Assertions.assertTrue(snapshot1.isEmpty());
         Assertions.assertEquals(cache.values().size(), 1);
         final Collection<String> snapshot2 = cache.snapshot();
-        cache2.put("456", "some other string");
+        cache2.put(456, "some other string");
         Assertions.assertEquals(cache.values().size(), 2);
         Assertions.assertEquals(snapshot2.size(), 1);
         

--- a/src/test/java/com/mewna/catnip/cache/view/DefaultCacheViewTests.java
+++ b/src/test/java/com/mewna/catnip/cache/view/DefaultCacheViewTests.java
@@ -37,14 +37,14 @@ public class DefaultCacheViewTests {
     @Test
     public void getById() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertEquals(cache.getById(123), "some string");
     }
     
     @Test
     public void size() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertEquals(cache.size(), 1);
     }
     
@@ -57,45 +57,45 @@ public class DefaultCacheViewTests {
     @Test
     public void isNotEmpty() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertFalse(cache.isEmpty());
     }
     
     @Test
     public void findAny() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertEquals(cache.findAny(__ -> true), "some string");
     }
     
     @Test
     public void findAnyNoMatches() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertNull(cache.findAny(__ -> false));
     }
     
     @Test
     public void find() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         Assertions.assertEquals(cache.find(__ -> true).size(), 2);
     }
     
     @Test
     public void findNoMatches() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         Assertions.assertTrue(cache.find(__ -> false).isEmpty());
     }
     
     @Test
     public void collect1() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         final List<String> list = cache.collect(Collectors.toList());
         Assertions.assertEquals(list.size(), 2);
         Assertions.assertTrue(list.contains("some string"));
@@ -105,8 +105,8 @@ public class DefaultCacheViewTests {
     @Test
     public void collect2() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         final List<String> list = cache.collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
         Assertions.assertEquals(list.size(), 2);
         Assertions.assertTrue(list.contains("some string"));
@@ -116,8 +116,8 @@ public class DefaultCacheViewTests {
     @Test
     public void reduce1() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         final String s = cache.reduce("", String::concat, String::concat);
         Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
         Assertions.assertTrue(
@@ -129,8 +129,8 @@ public class DefaultCacheViewTests {
     @Test
     public void reduce2() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         final String s = cache.reduce("", String::concat);
         Assertions.assertEquals(s.length(), "some string".length() + "some other string".length());
         Assertions.assertTrue(
@@ -149,8 +149,8 @@ public class DefaultCacheViewTests {
     @Test
     public void reduce3() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         final Optional<String> maybeS = cache.reduce(String::concat);
         Assertions.assertTrue(maybeS.isPresent());
         final String s = maybeS.get();
@@ -164,8 +164,8 @@ public class DefaultCacheViewTests {
     @Test
     public void anyMatch() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         Assertions.assertTrue(cache.anyMatch("some string"::equals));
     }
     
@@ -178,8 +178,8 @@ public class DefaultCacheViewTests {
     @Test
     public void allMatch() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         Assertions.assertFalse(cache.allMatch("some string"::equals));
     }
     
@@ -192,8 +192,8 @@ public class DefaultCacheViewTests {
     @Test
     public void noneMatch() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         Assertions.assertFalse(cache.noneMatch("some string"::equals));
     }
     
@@ -206,8 +206,8 @@ public class DefaultCacheViewTests {
     @Test
     public void min() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         final Optional<String> min = cache.min(Comparator.comparingInt(String::length));
         Assertions.assertTrue(min.isPresent());
         Assertions.assertEquals(min.get(), "some string");
@@ -216,8 +216,8 @@ public class DefaultCacheViewTests {
     @Test
     public void max() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
-        cache.put("123", "some string");
-        cache.put("456", "some other string");
+        cache.put(123, "some string");
+        cache.put(456, "some other string");
         final Optional<String> max = cache.max(Comparator.comparingInt(String::length));
         Assertions.assertTrue(max.isPresent());
         Assertions.assertEquals(max.get(), "some other string");
@@ -227,9 +227,9 @@ public class DefaultCacheViewTests {
     public void count() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
         Assertions.assertEquals(cache.count(__ -> true), 0);
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertEquals(cache.count(__ -> true), 1);
-        cache.put("456", "some other string");
+        cache.put(456, "some other string");
         Assertions.assertEquals(cache.count(__ -> true), 2);
         Assertions.assertEquals(cache.count("some string"::equals), 1);
         Assertions.assertEquals(cache.count("some other string"::equals), 1);
@@ -240,9 +240,9 @@ public class DefaultCacheViewTests {
     public void keys() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
         Assertions.assertTrue(cache.keys().isEmpty());
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertEquals(cache.keys().size(), 1);
-        cache.put("456", "some other string");
+        cache.put(456, "some other string");
         Assertions.assertEquals(cache.keys().size(), 2);
         
         Assertions.assertTrue(cache.keys().contains(123L));
@@ -254,9 +254,9 @@ public class DefaultCacheViewTests {
     public void values() {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
         Assertions.assertTrue(cache.values().isEmpty());
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertEquals(cache.values().size(), 1);
-        cache.put("456", "some other string");
+        cache.put(456, "some other string");
         Assertions.assertEquals(cache.values().size(), 2);
         
         Assertions.assertTrue(cache.values().contains("some string"));
@@ -269,11 +269,11 @@ public class DefaultCacheViewTests {
         final DefaultCacheView<String> cache = new DefaultCacheView<>();
         final Collection<String> snapshot1 = cache.snapshot();
         Assertions.assertTrue(cache.values().isEmpty());
-        cache.put("123", "some string");
+        cache.put(123, "some string");
         Assertions.assertTrue(snapshot1.isEmpty());
         Assertions.assertEquals(cache.values().size(), 1);
         final Collection<String> snapshot2 = cache.snapshot();
-        cache.put("456", "some other string");
+        cache.put(456, "some other string");
         Assertions.assertEquals(cache.values().size(), 2);
         Assertions.assertEquals(snapshot2.size(), 1);
     

--- a/src/test/java/com/mewna/catnip/cache/view/DefaultNamedCacheViewTests.java
+++ b/src/test/java/com/mewna/catnip/cache/view/DefaultNamedCacheViewTests.java
@@ -36,7 +36,7 @@ public class DefaultNamedCacheViewTests {
     @Test
     public void findByName() {
         final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
-        cache.put("123", "string");
+        cache.put(123, "string");
         Assertions.assertFalse(cache.findByName("string").isEmpty());
         Assertions.assertTrue(cache.findByName("StRiNg").isEmpty());
     }
@@ -44,14 +44,14 @@ public class DefaultNamedCacheViewTests {
     @Test
     public void findByNameIgnoreCase() {
         final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
-        cache.put("123", "string");
+        cache.put(123, "string");
         Assertions.assertFalse(cache.findByName("StRiNg", true).isEmpty());
     }
     
     @Test
     public void findByNameContains() {
         final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
-        cache.put("123", "string");
+        cache.put(123, "string");
         Assertions.assertFalse(cache.findByNameContains("tri").isEmpty());
         Assertions.assertTrue(cache.findByNameContains("tRi").isEmpty());
     }
@@ -59,14 +59,14 @@ public class DefaultNamedCacheViewTests {
     @Test
     public void findByNameContainsIgnoreCase() {
         final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
-        cache.put("123", "string");
+        cache.put(123, "string");
         Assertions.assertFalse(cache.findByNameContains("tRi", true).isEmpty());
     }
     
     @Test
     public void findByNameStartsWith() {
         final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
-        cache.put("123", "string");
+        cache.put(123, "string");
         Assertions.assertFalse(cache.findByNameStartsWith("str").isEmpty());
         Assertions.assertTrue(cache.findByNameStartsWith("StR").isEmpty());
     }
@@ -74,14 +74,14 @@ public class DefaultNamedCacheViewTests {
     @Test
     public void findByNameStartsWithIgnoreCase() {
         final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
-        cache.put("123", "string");
+        cache.put(123, "string");
         Assertions.assertFalse(cache.findByNameStartsWith("StR", true).isEmpty());
     }
     
     @Test
     public void findByNameEndsWith() {
         final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
-        cache.put("123", "string");
+        cache.put(123, "string");
         Assertions.assertFalse(cache.findByNameEndsWith("ing").isEmpty());
         Assertions.assertTrue(cache.findByNameEndsWith("iNg").isEmpty());
     }
@@ -89,7 +89,7 @@ public class DefaultNamedCacheViewTests {
     @Test
     public void findByNameEndsWithIgnoreCase() {
         final DefaultNamedCacheView<String> cache = new DefaultNamedCacheView<>(Function.identity());
-        cache.put("123", "string");
+        cache.put(123, "string");
         Assertions.assertFalse(cache.findByNameEndsWith("iNg", true).isEmpty());
     }
 }


### PR DESCRIPTION
- optimize reduce, min, max implementations in CacheViews
- get rid of unneeded allocations in MemoryEntityCache
- fully replaced string keys with long keys for cache writes
- remove unneeded allocation in DefaultCacheView#snapshot()

- fix wrong parse method used in EntityBuilder (parseLong -> parseUnsignedLong)
- fix Message#channel() returning null on DMs (wrong cache key)