### PR TITLE
Add sonarlint to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .idea/copyright/*.xml
 .idea/dictionaries/*.xml
 .idea/libraries
+.idea/sonarlint
 target/
 *.iml


### PR DESCRIPTION
I'm using https://www.sonarlint.org/ and this is rather annoying:

![image](https://user-images.githubusercontent.com/6048348/50550421-a70c9180-0c70-11e9-9448-56b52c599513.png)
