### PR TITLE
Improve event dispatching, shard startup, raw rest methods

### DIFF
--- a/src/main/java/com/mewna/catnip/Catnip.java
+++ b/src/main/java/com/mewna/catnip/Catnip.java
@@ -42,6 +42,7 @@ import com.mewna.catnip.rest.Rest;
 import com.mewna.catnip.rest.RestRequester;
 import com.mewna.catnip.rest.Routes;
 import com.mewna.catnip.shard.EventType;
+import com.mewna.catnip.shard.event.DispatchManager;
 import com.mewna.catnip.shard.event.EventBuffer;
 import com.mewna.catnip.shard.manager.ShardManager;
 import com.mewna.catnip.shard.ratelimit.Ratelimiter;
@@ -211,6 +212,15 @@ public interface Catnip {
     @Nonnull
     @CheckReturnValue
     EventBus eventBus();
+    
+    /**
+     * Handles dispatching and listening to events.
+     *
+     * @return The current dispatch manager instance.
+     */
+    @Nonnull
+    @CheckReturnValue
+    DispatchManager dispatchManager();
     
     /**
      * Start all shards asynchronously. To customize the shard spawning /
@@ -479,7 +489,7 @@ public interface Catnip {
      * @return The vert.x message consumer.
      */
     default <T> MessageConsumer<T> on(@Nonnull final EventType<T> type) {
-        return eventBus().consumer(type.key());
+        return dispatchManager().createConsumer(type.key());
     }
     
     /**
@@ -493,7 +503,7 @@ public interface Catnip {
      * @return The vert.x message consumer.
      */
     default <T> MessageConsumer<T> on(@Nonnull final EventType<T> type, @Nonnull final Consumer<T> handler) {
-        return eventBus().consumer(type.key(), message -> handler.accept(message.body()));
+        return on(type).handler(m -> handler.accept(m.body()));
     }
     
     /**

--- a/src/main/java/com/mewna/catnip/CatnipOptions.java
+++ b/src/main/java/com/mewna/catnip/CatnipOptions.java
@@ -38,6 +38,8 @@ import com.mewna.catnip.rest.bucket.BucketBackend;
 import com.mewna.catnip.rest.bucket.MemoryBucketBackend;
 import com.mewna.catnip.shard.DiscordEvent.Raw;
 import com.mewna.catnip.shard.event.CachingBuffer;
+import com.mewna.catnip.shard.event.DefaultDispatchManager;
+import com.mewna.catnip.shard.event.DispatchManager;
 import com.mewna.catnip.shard.event.EventBuffer;
 import com.mewna.catnip.shard.manager.DefaultShardManager;
 import com.mewna.catnip.shard.manager.ShardManager;
@@ -117,6 +119,11 @@ public final class CatnipOptions implements Cloneable {
      */
     @Nonnull
     private BucketBackend restBucketBackend = new MemoryBucketBackend();
+    /**
+     * Manages event dispatching and consumers. Defaults to {@link DefaultDispatchManager}.
+     */
+    @Nonnull
+    private DispatchManager dispatchManager = new DefaultDispatchManager();
     /**
      * Whether or not catnip should chunk members. Do not disable this if you
      * don't know what it does.

--- a/src/main/java/com/mewna/catnip/extension/AbstractExtension.java
+++ b/src/main/java/com/mewna/catnip/extension/AbstractExtension.java
@@ -78,7 +78,7 @@ public abstract class AbstractExtension extends AbstractVerticle implements Exte
     
     @Override
     public <T> MessageConsumer<T> on(@Nonnull final EventType<T> type) {
-        final MessageConsumer<T> consumer = catnip().eventBus().consumer(type.key());
+        final MessageConsumer<T> consumer = catnip().dispatchManager().createConsumer(type.key());
         context.addCloseHook(consumer::unregister);
         return consumer;
     }

--- a/src/main/java/com/mewna/catnip/internal/CatnipImpl.java
+++ b/src/main/java/com/mewna/catnip/internal/CatnipImpl.java
@@ -50,6 +50,7 @@ import com.mewna.catnip.shard.CatnipShard;
 import com.mewna.catnip.shard.CatnipShard.ShardConnectState;
 import com.mewna.catnip.shard.ShardControlMessage;
 import com.mewna.catnip.shard.ShardInfo;
+import com.mewna.catnip.shard.event.DispatchManager;
 import com.mewna.catnip.shard.event.EventBuffer;
 import com.mewna.catnip.shard.manager.ShardManager;
 import com.mewna.catnip.shard.ratelimit.Ratelimiter;
@@ -97,6 +98,7 @@ public class CatnipImpl implements Catnip {
     private final Set<String> unavailableGuilds = ConcurrentHashMap.newKeySet();
     private final AtomicReference<GatewayInfo> gatewayInfo = new AtomicReference<>(null);
     
+    private DispatchManager dispatchManager;
     private RestRequester requester;
     private ShardManager shardManager;
     private SessionManager sessionManager;
@@ -124,6 +126,7 @@ public class CatnipImpl implements Catnip {
         // so that we don't need to update this every single time that the
         // options change.
         this.options = options;
+        dispatchManager = options.dispatchManager();
         requester = new RestRequester(this, options.restBucketBackend(), options.restHttpClient());
         shardManager = options.shardManager();
         sessionManager = options.sessionManager();
@@ -329,6 +332,7 @@ public class CatnipImpl implements Catnip {
     
     private void injectSelf() {
         // Inject catnip instance into dependent fields
+        dispatchManager.catnip(this);
         shardManager.catnip(this);
         eventBuffer.catnip(this);
         cache.catnip(this);

--- a/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
@@ -231,15 +231,15 @@ public class RestGuild extends RestHandler {
     @Nonnull
     @CheckReturnValue
     public CompletionStage<Guild> createGuild(@Nonnull final GuildData guild) {
-        return createGuildRaw(guild.toJson()).thenApply(entityBuilder()::createGuild);
+        return createGuildRaw(guild).thenApply(entityBuilder()::createGuild);
     }
     
     @Nonnull
     @CheckReturnValue
-    public CompletionStage<JsonObject> createGuildRaw(@Nonnull final JsonObject guild) {
+    public CompletionStage<JsonObject> createGuildRaw(@Nonnull final GuildData guild) {
         return catnip().requester()
                 .queue(new OutboundRequest(Routes.CREATE_GUILD,
-                        ImmutableMap.of(), guild))
+                        ImmutableMap.of(), guild.toJson()))
                 .thenApply(ResponsePayload::object);
     }
     
@@ -286,13 +286,13 @@ public class RestGuild extends RestHandler {
     
     @Nonnull
     public CompletionStage<Guild> modifyGuild(@Nonnull final String guildId, @Nonnull final GuildEditFields fields) {
-        return modifyGuildRaw(guildId, fields.payload()).thenApply(entityBuilder()::createGuild);
+        return modifyGuildRaw(guildId, fields).thenApply(entityBuilder()::createGuild);
     }
     
     @Nonnull
-    public CompletionStage<JsonObject> modifyGuildRaw(@Nonnull final String guildId, @Nonnull final JsonObject fields) {
+    public CompletionStage<JsonObject> modifyGuildRaw(@Nonnull final String guildId, @Nonnull final GuildEditFields fields) {
         return catnip().requester().queue(new OutboundRequest(Routes.MODIFY_GUILD.withMajorParam(guildId),
-                ImmutableMap.of(), fields))
+                ImmutableMap.of(), fields.payload()))
                 .thenApply(ResponsePayload::object);
     }
     

--- a/src/main/java/com/mewna/catnip/rest/handler/RestUser.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestUser.java
@@ -93,6 +93,11 @@ public class RestUser extends RestHandler {
     
     @Nonnull
     public CompletionStage<User> modifyCurrentUser(@Nullable final String username, @Nullable final URI avatarData) {
+        return modifyCurrentUserRaw(username, avatarData).thenApply(entityBuilder()::createUser);
+    }
+    
+    @Nonnull
+    public CompletionStage<JsonObject> modifyCurrentUserRaw(@Nullable final String username, @Nullable final URI avatarData) {
         final JsonObject body = new JsonObject();
         if(avatarData != null) {
             Utils.validateImageUri(avatarData);
@@ -100,11 +105,6 @@ public class RestUser extends RestHandler {
         }
         body.put("username", username);
         
-        return modifyCurrentUserRaw(body).thenApply(entityBuilder()::createUser);
-    }
-    
-    @Nonnull
-    public CompletionStage<JsonObject> modifyCurrentUserRaw(@Nonnull final JsonObject body) {
         return catnip().requester().queue(new OutboundRequest(Routes.MODIFY_CURRENT_USER,
                 ImmutableMap.of(), body))
                 .thenApply(ResponsePayload::object);
@@ -162,14 +162,15 @@ public class RestUser extends RestHandler {
     @Nonnull
     @CheckReturnValue
     public CompletionStage<DMChannel> createDM(@Nonnull final String recipientId) {
-        return createDMRaw(new JsonObject().put("recipient_id", recipientId))
+        return createDMRaw(recipientId)
                 .thenApply(entityBuilder()::createUserDM);
     }
     
     @Nonnull
     @CheckReturnValue
-    public CompletionStage<JsonObject> createDMRaw(@Nonnull final JsonObject body) {
-        return catnip().requester().queue(new OutboundRequest(Routes.CREATE_DM, ImmutableMap.of(), body))
+    public CompletionStage<JsonObject> createDMRaw(@Nonnull final String recipientId) {
+        return catnip().requester().queue(new OutboundRequest(Routes.CREATE_DM, ImmutableMap.of(),
+                new JsonObject().put("recipient_id", recipientId)))
                 .thenApply(ResponsePayload::object);
     }
     

--- a/src/main/java/com/mewna/catnip/shard/CatnipShard.java
+++ b/src/main/java/com/mewna/catnip/shard/CatnipShard.java
@@ -489,7 +489,7 @@ public class CatnipShard extends AbstractVerticle {
             case "READY": {
                 catnip.sessionManager().session(id, data.getString("session_id"));
                 // Reply after IDENTIFY ratelimit
-                catnip.vertx().setTimer(5500L, __ -> msg.reply(READY));
+                msg.reply(READY);
                 catnip.eventBus().publish(Raw.IDENTIFIED, shardInfo());
                 break;
             }

--- a/src/main/java/com/mewna/catnip/shard/DispatchEmitter.java
+++ b/src/main/java/com/mewna/catnip/shard/DispatchEmitter.java
@@ -89,73 +89,73 @@ public final class DispatchEmitter {
                         .forEach(((CatnipImpl) catnip)::markUnavailable);
                 final Ready ready = entityBuilder.createReady(data);
                 ((CatnipImpl) catnip).selfUser(ready.user());
-                catnip.eventBus().publish(type, ready);
+                catnip.dispatchManager().dispatchEvent(type, ready);
                 break;
             }
             case Raw.RESUMED: {
                 final Resumed resumed = entityBuilder.createResumed(data);
-                catnip.eventBus().publish(type, resumed);
+                catnip.dispatchManager().dispatchEvent(type, resumed);
                 break;
             }
             
             // Messages
             case Raw.MESSAGE_CREATE: {
-                catnip.eventBus().publish(type, entityBuilder.createMessage(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createMessage(data));
                 break;
             }
             case Raw.MESSAGE_UPDATE: {
                 if(data.getJsonObject("author", null) == null) {
                     // Embeds update, emit the special case
-                    catnip.eventBus().publish(Raw.MESSAGE_EMBEDS_UPDATE, entityBuilder.createMessageEmbedUpdate(data));
+                    catnip.dispatchManager().dispatchEvent(Raw.MESSAGE_EMBEDS_UPDATE, entityBuilder.createMessageEmbedUpdate(data));
                 } else {
-                    catnip.eventBus().publish(type, entityBuilder.createMessage(data));
+                    catnip.dispatchManager().dispatchEvent(type, entityBuilder.createMessage(data));
                 }
                 break;
             }
             case Raw.MESSAGE_DELETE: {
-                catnip.eventBus().publish(type, entityBuilder.createDeletedMessage(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createDeletedMessage(data));
                 break;
             }
             case Raw.MESSAGE_DELETE_BULK: {
-                catnip.eventBus().publish(type, entityBuilder.createBulkDeletedMessages(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createBulkDeletedMessages(data));
                 break;
             }
             case Raw.TYPING_START: {
-                catnip.eventBus().publish(type, entityBuilder.createTypingUser(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createTypingUser(data));
                 break;
             }
             case Raw.MESSAGE_REACTION_REMOVE_ALL: {
-                catnip.eventBus().publish(type, entityBuilder.createBulkRemovedReactions(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createBulkRemovedReactions(data));
                 break;
             }
             case Raw.MESSAGE_REACTION_REMOVE: {
-                catnip.eventBus().publish(type, entityBuilder.createReactionUpdate(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createReactionUpdate(data));
                 break;
             }
             case Raw.MESSAGE_REACTION_ADD: {
-                catnip.eventBus().publish(type, entityBuilder.createReactionUpdate(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createReactionUpdate(data));
                 break;
             }
             
             // Channels
             case Raw.CHANNEL_CREATE: {
-                catnip.eventBus().publish(type, entityBuilder.createChannel(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createChannel(data));
                 break;
             }
             case Raw.CHANNEL_UPDATE: {
-                catnip.eventBus().publish(type, entityBuilder.createChannel(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createChannel(data));
                 break;
             }
             case Raw.CHANNEL_DELETE: {
-                catnip.eventBus().publish(type, entityBuilder.createChannel(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createChannel(data));
                 break;
             }
             case Raw.CHANNEL_PINS_UPDATE: {
-                catnip.eventBus().publish(type, entityBuilder.createChannelPinsUpdate(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createChannelPinsUpdate(data));
                 break;
             }
             case Raw.WEBHOOKS_UPDATE: {
-                catnip.eventBus().publish(type, entityBuilder.createWebhooksUpdate(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createWebhooksUpdate(data));
                 break;
             }
             
@@ -164,72 +164,72 @@ public final class DispatchEmitter {
                 final String id = data.getString("id");
                 final Guild guild = entityBuilder.createGuild(data);
                 if(catnip.isUnavailable(id)) {
-                    catnip.eventBus().publish(Raw.GUILD_AVAILABLE, guild);
+                    catnip.dispatchManager().dispatchEvent(Raw.GUILD_AVAILABLE, guild);
                     ((CatnipImpl) catnip).markAvailable(id);
                 } else {
-                    catnip.eventBus().publish(type, guild);
+                    catnip.dispatchManager().dispatchEvent(type, guild);
                 }
                 break;
             }
             case Raw.GUILD_UPDATE: {
-                catnip.eventBus().publish(type, entityBuilder.createGuild(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createGuild(data));
                 break;
             }
             case Raw.GUILD_DELETE: {
                 final String id = data.getString("id");
                 if(data.getBoolean("unavailable", false)) {
                     ((CatnipImpl) catnip).markUnavailable(id);
-                    catnip.eventBus().publish(Raw.GUILD_UNAVAILABLE, entityBuilder.createUnavailableGuild(data));
+                    catnip.dispatchManager().dispatchEvent(Raw.GUILD_UNAVAILABLE, entityBuilder.createUnavailableGuild(data));
                 } else {
-                    catnip.eventBus().publish(type, entityBuilder.createGuild(data));
+                    catnip.dispatchManager().dispatchEvent(type, entityBuilder.createGuild(data));
                 }
                 break;
             }
             case Raw.GUILD_BAN_ADD: {
-                catnip.eventBus().publish(type, entityBuilder.createGatewayGuildBan(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createGatewayGuildBan(data));
                 break;
             }
             case Raw.GUILD_BAN_REMOVE: {
-                catnip.eventBus().publish(type, entityBuilder.createGatewayGuildBan(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createGatewayGuildBan(data));
                 break;
             }
             case Raw.GUILD_INTEGRATIONS_UPDATE: {
-                catnip.eventBus().publish(type, data.getString("guild_id"));
+                catnip.dispatchManager().dispatchEvent(type, data.getString("guild_id"));
                 break;
             }
             
             // Roles
             case Raw.GUILD_ROLE_CREATE: {
-                catnip.eventBus().publish(type, entityBuilder.createRole(data.getString("guild_id"), data.getJsonObject("role")));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createRole(data.getString("guild_id"), data.getJsonObject("role")));
                 break;
             }
             case Raw.GUILD_ROLE_UPDATE: {
-                catnip.eventBus().publish(type, entityBuilder.createRole(data.getString("guild_id"), data.getJsonObject("role")));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createRole(data.getString("guild_id"), data.getJsonObject("role")));
                 break;
             }
             case Raw.GUILD_ROLE_DELETE: {
-                catnip.eventBus().publish(type, entityBuilder.createPartialRole(data.getString("guild_id"), data.getString("role_id")));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createPartialRole(data.getString("guild_id"), data.getString("role_id")));
                 break;
             }
             
             // Emoji
             case Raw.GUILD_EMOJIS_UPDATE: {
-                catnip.eventBus().publish(type, entityBuilder.createGuildEmojisUpdate(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createGuildEmojisUpdate(data));
                 break;
             }
             
             // Members
             case Raw.GUILD_MEMBER_ADD: {
-                catnip.eventBus().publish(type, entityBuilder.createMember(data.getString("guild_id"), data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createMember(data.getString("guild_id"), data));
                 break;
             }
             case Raw.GUILD_MEMBER_REMOVE: {
-                catnip.eventBus().publish(type, entityBuilder.createMember(data.getString("guild_id"), data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createMember(data.getString("guild_id"), data));
                 break;
             }
             case Raw.GUILD_MEMBER_UPDATE: {
                 final String guild = data.getString("guild_id");
-                catnip.eventBus().publish(type, entityBuilder.createPartialMember(guild, data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createPartialMember(guild, data));
                 break;
             }
             
@@ -237,7 +237,7 @@ public final class DispatchEmitter {
             case Raw.USER_UPDATE: {
                 final User user = entityBuilder.createUser(data);
                 ((CatnipImpl) user).selfUser(user);
-                catnip.eventBus().publish(type, user);
+                catnip.dispatchManager().dispatchEvent(type, user);
                 break;
             }
             case Raw.PRESENCE_UPDATE: {
@@ -249,17 +249,17 @@ public final class DispatchEmitter {
                             "but we should never get this. If you report this to Discord, include the following " +
                             "JSON in your report:\n{}", clone.encodePrettily());
                 }
-                catnip.eventBus().publish(type, presence);
+                catnip.dispatchManager().dispatchEvent(type, presence);
                 break;
             }
             
             // Voice
             case Raw.VOICE_STATE_UPDATE: {
-                catnip.eventBus().publish(type, entityBuilder.createVoiceState(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createVoiceState(data));
                 break;
             }
             case Raw.VOICE_SERVER_UPDATE: {
-                catnip.eventBus().publish(type, entityBuilder.createVoiceServerUpdate(data));
+                catnip.dispatchManager().dispatchEvent(type, entityBuilder.createVoiceServerUpdate(data));
                 break;
             }
             

--- a/src/main/java/com/mewna/catnip/shard/event/AbstractDispatchManager.java
+++ b/src/main/java/com/mewna/catnip/shard/event/AbstractDispatchManager.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 amy, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.mewna.catnip.shard.event;
+
+import com.mewna.catnip.Catnip;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+public abstract class AbstractDispatchManager implements DispatchManager {
+    @Getter
+    @Accessors(fluent = true)
+    private volatile Catnip catnip;
+    
+    @Override
+    public void catnip(final Catnip catnip) {
+        this.catnip = catnip;
+    }
+}

--- a/src/main/java/com/mewna/catnip/shard/event/AbstractDispatchManager.java
+++ b/src/main/java/com/mewna/catnip/shard/event/AbstractDispatchManager.java
@@ -34,7 +34,7 @@ import lombok.experimental.Accessors;
 public abstract class AbstractDispatchManager implements DispatchManager {
     @Getter
     @Accessors(fluent = true)
-    private volatile Catnip catnip;
+    private Catnip catnip;
     
     @Override
     public void catnip(final Catnip catnip) {

--- a/src/main/java/com/mewna/catnip/shard/event/DefaultDispatchManager.java
+++ b/src/main/java/com/mewna/catnip/shard/event/DefaultDispatchManager.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 amy, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.mewna.catnip.shard.event;
+
+import io.vertx.core.eventbus.MessageConsumer;
+
+public class DefaultDispatchManager extends AbstractDispatchManager {
+    @Override
+    public void dispatchEvent(final String address, final Object event) {
+        catnip().eventBus().publish(address, event);
+    }
+    
+    @Override
+    public <T> MessageConsumer<T> createConsumer(final String address) {
+        return catnip().eventBus().consumer(address);
+    }
+}

--- a/src/main/java/com/mewna/catnip/shard/event/DispatchManager.java
+++ b/src/main/java/com/mewna/catnip/shard/event/DispatchManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019 amy, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.mewna.catnip.shard.event;
+
+import com.mewna.catnip.Catnip;
+import io.vertx.core.eventbus.MessageConsumer;
+
+public interface DispatchManager {
+    void catnip(Catnip catnip);
+    
+    /**
+     * Dispatches an event to the provided address.
+     *
+     * @param address Address to send the event to.
+     * @param event Event to dispatch.
+     */
+    void dispatchEvent(String address, Object event);
+    
+    /**
+     * Returns a consumer listening on the provided address.
+     *
+     * @param address Address to listen on.
+     * @param <T> Type of the event handled by the consumer.
+     *
+     * @return A consumer listening on the provided address.
+     */
+    <T> MessageConsumer<T> createConsumer(String address);
+}

--- a/src/main/java/com/mewna/catnip/shard/manager/DefaultShardManager.java
+++ b/src/main/java/com/mewna/catnip/shard/manager/DefaultShardManager.java
@@ -153,18 +153,25 @@ public class DefaultShardManager extends AbstractShardManager {
                     if(reply.succeeded()) {
                         final ShardConnectState state = reply.result().body();
                         switch(state) {
-                            case READY:
+                            case READY: {
+                                catnip().logAdapter().info("Connected shard {}", nextId);
+                                catnip().vertx().setTimer(5500, __ -> poll());
+                                break;
+                            }
                             case RESUMED: {
-                                catnip().logAdapter().info("Connected shard {} with state {}", nextId, reply.result().body());
+                                catnip().logAdapter().info("Resumed shard {}", nextId);
+                                poll();
                                 break;
                             }
                             case FAILED: {
                                 catnip().logAdapter().warn("Failed connecting shard {}, re-queueing", nextId);
                                 addToConnectQueue(nextId);
+                                poll();
                                 break;
                             }
                             default: {
                                 catnip().logAdapter().error("Got unexpected / unknown shard connect state: {}", state);
+                                poll();
                                 break;
                             }
                         }
@@ -172,8 +179,8 @@ public class DefaultShardManager extends AbstractShardManager {
                     } else {
                         catnip().logAdapter().warn("Failed connecting shard {} entirely, re-queueing", nextId);
                         addToConnectQueue(nextId);
+                        poll();
                     }
-                    poll();
                 });
     }
     


### PR DESCRIPTION
- Added DispatchManager interface
  - Responsible for creating MessageConsumer instances and dispatching events
  - Useful to control how messages are sent across a cluster, eg only deliver them locally
- ShardManager is now responsible for the IDENTIFY backoff
  - Easier to manage backoff across a cluster
- Raw rest methods don't take JSON objects as arguments anymore