### PR TITLE
Move SelfUser caching to EntityCache

### DIFF
--- a/src/main/java/com/mewna/catnip/cache/EntityCache.java
+++ b/src/main/java/com/mewna/catnip/cache/EntityCache.java
@@ -454,4 +454,11 @@ public interface EntityCache {
      */
     @Nonnull
     CacheView<VoiceState> voiceStates();
+    
+    /**
+     * @return The currently-logged-in user. May be {@code null} if no shards
+     * have logged in.
+     */
+    @Nullable
+    User selfUser();
 }

--- a/src/main/java/com/mewna/catnip/cache/MemoryEntityCache.java
+++ b/src/main/java/com/mewna/catnip/cache/MemoryEntityCache.java
@@ -714,6 +714,12 @@ public abstract class MemoryEntityCache implements EntityCacheWorker {
         return new CompositeCacheView<>(voiceStateCache.values());
     }
     
+    @Nullable
+    @Override
+    public User selfUser() {
+        return selfUser.get();
+    }
+    
     @Nonnull
     @Override
     public EntityCache catnip(@Nonnull final Catnip catnip) {

--- a/src/main/java/com/mewna/catnip/cache/NoopEntityCache.java
+++ b/src/main/java/com/mewna/catnip/cache/NoopEntityCache.java
@@ -317,6 +317,12 @@ public class NoopEntityCache implements EntityCacheWorker {
         return CacheView.empty();
     }
     
+    @Nullable
+    @Override
+    public User selfUser() {
+        return null;
+    }
+    
     @Nonnull
     @Override
     public EntityCache catnip(@Nonnull final Catnip catnip) {

--- a/src/main/java/com/mewna/catnip/internal/CatnipImpl.java
+++ b/src/main/java/com/mewna/catnip/internal/CatnipImpl.java
@@ -97,7 +97,6 @@ public class CatnipImpl implements Catnip {
     
     private final Rest rest = new Rest(this);
     private final ExtensionManager extensionManager = new DefaultExtensionManager(this);
-    private final AtomicReference<User> selfUser = new AtomicReference<>(null);
     private final Set<String> unavailableGuilds = ConcurrentHashMap.newKeySet();
     private final AtomicReference<GatewayInfo> gatewayInfo = new AtomicReference<>(null);
     
@@ -208,7 +207,7 @@ public class CatnipImpl implements Catnip {
     @Nullable
     @Override
     public User selfUser() {
-        return selfUser.get();
+        return cache().selfUser();
     }
     
     @Override
@@ -217,13 +216,6 @@ public class CatnipImpl implements Catnip {
         if(vertx) {
             this.vertx.close();
         }
-    }
-    
-    @Nonnull
-    @SuppressWarnings("UnusedReturnValue")
-    public Catnip selfUser(@Nonnull final User self) {
-        selfUser.set(self);
-        return this;
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/shard/DispatchEmitter.java
+++ b/src/main/java/com/mewna/catnip/shard/DispatchEmitter.java
@@ -88,7 +88,6 @@ public final class DispatchEmitter {
                         .map(Snowflake::id)
                         .forEach(((CatnipImpl) catnip)::markUnavailable);
                 final Ready ready = entityBuilder.createReady(data);
-                ((CatnipImpl) catnip).selfUser(ready.user());
                 catnip.dispatchManager().dispatchEvent(type, ready);
                 break;
             }
@@ -236,7 +235,6 @@ public final class DispatchEmitter {
             // Users
             case Raw.USER_UPDATE: {
                 final User user = entityBuilder.createUser(data);
-                ((CatnipImpl) user).selfUser(user);
                 catnip.dispatchManager().dispatchEvent(type, user);
                 break;
             }


### PR DESCRIPTION
Fixes #185 

Should the catnip.selfUser() method be nixed in favor of using catnip.cache().selfUser()?