### PR TITLE
Fixed mewna/catnip#162

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/impl/AuditLogChangeImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/AuditLogChangeImpl.java
@@ -51,7 +51,9 @@ public class AuditLogChangeImpl implements AuditLogChange, RequiresCatnip {
     @JsonIgnore
     private transient Catnip catnip;
     
+    @JsonProperty
     private Object oldValue;
+    @JsonProperty
     private Object newValue;
     private String key;
     

--- a/src/main/java/com/mewna/catnip/entity/impl/ChannelPinsUpdateImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/ChannelPinsUpdateImpl.java
@@ -55,6 +55,7 @@ public class ChannelPinsUpdateImpl implements ChannelPinsUpdate, RequiresCatnip,
     private transient Catnip catnip;
     
     private long channelIdAsLong;
+    @JsonProperty
     private String lastPinTimestamp;
     
     @Nullable

--- a/src/main/java/com/mewna/catnip/entity/impl/CreatedInviteImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/CreatedInviteImpl.java
@@ -63,6 +63,7 @@ public class CreatedInviteImpl implements CreatedInvite, RequiresCatnip, Timesta
     private int maxUses;
     private int maxAge;
     private boolean temporary;
+    @JsonProperty
     private String createdAt;
     private boolean revoked;
     

--- a/src/main/java/com/mewna/catnip/entity/impl/EmbedImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EmbedImpl.java
@@ -54,6 +54,7 @@ public class EmbedImpl implements Embed, Timestamped {
     private EmbedType type;
     private String description;
     private String url;
+    @JsonProperty
     private String timestamp;
     private Integer color;
     private Footer footer;
@@ -62,6 +63,7 @@ public class EmbedImpl implements Embed, Timestamped {
     private Video video;
     private Provider provider;
     private Author author;
+    @JsonProperty
     private List<? extends Field> fields;
     
     @Override

--- a/src/main/java/com/mewna/catnip/entity/impl/GuildImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/GuildImpl.java
@@ -81,6 +81,7 @@ public class GuildImpl implements Guild, RequiresCatnip, Timestamped {
     private boolean widgetEnabled;
     private long widgetChannelIdAsLong;
     private long systemChannelIdAsLong;
+    @JsonProperty
     private String joinedAt;
     private boolean large;
     private boolean unavailable;

--- a/src/main/java/com/mewna/catnip/entity/impl/MemberImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/MemberImpl.java
@@ -58,6 +58,7 @@ public class MemberImpl implements Member, RequiresCatnip, Timestamped {
     private long guildIdAsLong;
     private String nick;
     private Set<String> roleIds;
+    @JsonProperty
     private String joinedAt;
     private boolean deaf;
     private boolean mute;

--- a/src/main/java/com/mewna/catnip/entity/impl/MessageImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/MessageImpl.java
@@ -64,14 +64,18 @@ public class MessageImpl implements Message, RequiresCatnip, Timestamped {
     private long channelIdAsLong;
     private User author;
     private String content;
+    @JsonProperty
     private String timestamp;
+    @JsonProperty
     private String editedTimestamp;
     private boolean tts;
     private boolean mentionsEveryone;
     private List<User> mentionedUsers;
     private List<String> mentionedRoles;
+    @JsonProperty
     private List<Attachment> attachments;
     private List<Embed> embeds;
+    @JsonProperty
     private List<Reaction> reactions;
     private String nonce;
     private boolean pinned;


### PR DESCRIPTION
Jackson does not serialize fields when there is a method with the same name in the same class.
There is a workaround for this by adding the `@JsonProperty` annotation above of those variables

```- Added @JsonProperty Annotation to variables when there is a method with the exact same name in the sae class```