### PR TITLE
Add "readable descriptions" in Permission Enum

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/util/Permission.java
+++ b/src/main/java/com/mewna/catnip/entity/util/Permission.java
@@ -40,35 +40,35 @@ import java.util.Set;
  */
 @Accessors(fluent = true)
 public enum Permission {
-    CREATE_INSTANT_INVITE(0x00000001, true),
-    KICK_MEMBERS(0x00000002, false),
-    BAN_MEMBERS(0x00000004, false),
-    ADMINISTRATOR(0x00000008, false),
-    MANAGE_CHANNELS(0x00000010, true),
-    MANAGE_GUILD(0x00000020, false),
-    ADD_REACTIONS(0x00000040, true),
-    VIEW_AUDIT_LOG(0x00000080, false),
-    VIEW_CHANNEL(0x00000400, true),
-    SEND_MESSAGES(0x00000800, true),
-    SEND_TTS_MESSAGES(0x00001000, true),
-    MANAGE_MESSAGES(0x00002000, true),
-    EMBED_LINKS(0x00004000, true),
-    ATTACH_FILES(0x00008000, true),
-    READ_MESSAGE_HISTORY(0x00010000, true),
-    MENTION_EVERYONE(0x00020000, true),
-    USE_EXTERNAL_EMOJI(0x00040000, true),
-    CONNECT(0x00100000, true),
-    SPEAK(0x00200000, true),
-    MUTE_MEMBERS(0x00400000, true),
-    DEAFEN_MEMBERS(0x00800000, true),
-    MOVE_MEMBERS(0x01000000, true),
-    USE_VAD(0x02000000, true),
-    PRIORITY_SPEAKER(0x00000100, true),
-    CHANGE_NICKNAME(0x04000000, false),
-    MANAGE_NICKNAME(0x08000000, false),
-    MANAGE_ROLES(0x10000000, true),
-    MANAGE_WEBHOOKS(0x20000000, true),
-    MANAGE_EMOJI(0x40000000, false);
+    CREATE_INSTANT_INVITE(0x00000001, true, "Create Instant Invite"),
+    KICK_MEMBERS(0x00000002, false, "Kick Members"),
+    BAN_MEMBERS(0x00000004, false, "Ban Members"),
+    ADMINISTRATOR(0x00000008, false, "Administrator"),
+    MANAGE_CHANNELS(0x00000010, true, "Manage Channels"),
+    MANAGE_GUILD(0x00000020, false, "Manage Server"),
+    ADD_REACTIONS(0x00000040, true, "Add Reactions"),
+    VIEW_AUDIT_LOG(0x00000080, false, "View Audit Logs"),
+    VIEW_CHANNEL(0x00000400, true, "Read Text Channels & See Voice Channels"),
+    SEND_MESSAGES(0x00000800, true, "Send Messages"),
+    SEND_TTS_MESSAGES(0x00001000, true, "Send TTS Messages"),
+    MANAGE_MESSAGES(0x00002000, true, "Manage Messages"),
+    EMBED_LINKS(0x00004000, true, "Embed Links"),
+    ATTACH_FILES(0x00008000, true, "Attach Files"),
+    READ_MESSAGE_HISTORY(0x00010000, true, "Read History"),
+    MENTION_EVERYONE(0x00020000, true, "Mention Everyone"),
+    USE_EXTERNAL_EMOJI(0x00040000, true, "Use External Emojis"),
+    CONNECT(0x00100000, true, "Connect"),
+    SPEAK(0x00200000, true, "Speak"),
+    MUTE_MEMBERS(0x00400000, true, "Mute Members"),
+    DEAFEN_MEMBERS(0x00800000, true, "Deafen Members"),
+    MOVE_MEMBERS(0x01000000, true, "Move Members"),
+    USE_VAD(0x02000000, true, "Use Voice Activity"),
+    PRIORITY_SPEAKER(0x00000100, true, "Priority Speaker"),
+    CHANGE_NICKNAME(0x04000000, false, "Change Nickname"),
+    MANAGE_NICKNAME(0x08000000, false, "Manage Nicknames"),
+    MANAGE_ROLES(0x10000000, true, "Manage Roles"),
+    MANAGE_WEBHOOKS(0x20000000, true, "Manage Webhooks"),
+    MANAGE_EMOJI(0x40000000, false, "Manage Emojis");
     
     public static final long ALL = from(Permission.values());
     public static final long NONE = 0;
@@ -76,9 +76,13 @@ public enum Permission {
     private final int value;
     @Getter
     private final boolean channel;
-    Permission(final int value, final boolean channel) {
+    @Getter
+    private final String permName;
+    
+    Permission(final int value, final boolean channel, final String permName) {
         this.value = value;
         this.channel = channel;
+        this.permName = permName;
     }
     
     public static Set<Permission> toSet(final long asLong) {


### PR DESCRIPTION
Adds an String with the permission name on the Discord Client in the Permission Enum. 