### PR TITLE
Use HashSet instead of ArrayList to remove duplicates

### DIFF
--- a/src/main/java/com/mewna/catnip/cache/view/CompositeCacheView.java
+++ b/src/main/java/com/mewna/catnip/cache/view/CompositeCacheView.java
@@ -102,7 +102,7 @@ public class CompositeCacheView<T> implements CacheView<T> {
     @Nonnull
     @Override
     public Collection<T> find(@Nonnull final Predicate<? super T> filter) {
-        final Collection<T> collection = new ArrayList<>();
+        final Collection<T> collection = new HashSet<>();
         for(final CacheView<T> c : sources) {
             c.find(filter, () -> collection);
         }


### PR DESCRIPTION
There is already no ordering, so there's no reason to use a list