### PR TITLE
fix audit logs and introduce actual http errors instead of only handling 400's

### DIFF
--- a/src/main/java/com/mewna/catnip/rest/ResponseException.java
+++ b/src/main/java/com/mewna/catnip/rest/ResponseException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 amy, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.mewna.catnip.rest;
+
+/**
+ * @author SamOphis
+ * @since 02/09/2019
+ */
+public class ResponseException extends Exception {
+    public ResponseException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
@@ -515,7 +515,7 @@ public class RestGuild extends RestHandler {
             builder.append("before", beforeEntryId);
         }
         
-        if(limit <= 100) {
+        if(limit <= 100 && limit >= 1) {
             builder.append("limit", Integer.toString(limit));
         }
         

--- a/src/main/java/com/mewna/catnip/rest/requester/AbstractRequester.java
+++ b/src/main/java/com/mewna/catnip/rest/requester/AbstractRequester.java
@@ -30,6 +30,7 @@ package com.mewna.catnip.rest.requester;
 import com.mewna.catnip.Catnip;
 import com.mewna.catnip.extension.Extension;
 import com.mewna.catnip.extension.hook.CatnipHook;
+import com.mewna.catnip.rest.ResponseException;
 import com.mewna.catnip.rest.ResponsePayload;
 import com.mewna.catnip.rest.RestPayloadException;
 import com.mewna.catnip.rest.Routes.Route;
@@ -261,6 +262,16 @@ public abstract class AbstractRequester implements Requester {
                     failures.put(e.getKey(), errorStrings);
                 });
                 request.future().completeExceptionally(new RestPayloadException(failures));
+                updateBucket(r.route(), headers, -1, latency);
+                request.bucket().requestDone();
+            } else if(statusCode > 400) {
+                final JsonObject response = payload.object();
+                final String message = response.getString("message", "No message.");
+                final int code = response.getInteger("code", -1);
+                final ResponseException exception = code != -1
+                        ? new ResponseException(String.format("HTTP Error Code: %d | JSON Message: %s | JSON Error Code: %d", statusCode, message, code))
+                        : new ResponseException(String.format("HTTP Error Code: %d | JSON Message: %s", statusCode, message));
+                request.future().completeExceptionally(exception);
                 updateBucket(r.route(), headers, -1, latency);
                 request.bucket().requestDone();
             } else {


### PR DESCRIPTION
__***yes this is tested***__
but nah fr, this is tested and should close #231 (except for the fact that i can't reproduce the 400 bad request)

it wasn't my code causing the issues either which is a first. now any response code which is not 429 or 400 creates a neatly-formatted `ResponseException` which you can respond to by using `CompletionStage#exceptionally`.

i'd recommend creating a new tag for this as `0.13.3` is effectively broken when dealing with audit logs