### PR TITLE
cleanup SafeVertxCompletableFuture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: maven:3.5.3-jdk-8
+      - image: maven:3.6.0-jdk-11
     working_directory: ~/catnip
 
     environment:

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,7 +6,7 @@
     <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true" />
     <option name="JD_ADD_BLANK_AFTER_RETURN" value="true" />
     <option name="FORMATTER_TAGS_ENABLED" value="true" />
-    <JSCodeStyleSettings>
+    <JSCodeStyleSettings version="0">
       <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
     </JSCodeStyleSettings>
     <JavaCodeStyleSettings>

--- a/src/main/java/com/mewna/catnip/util/SafeVertxCompletableFuture.java
+++ b/src/main/java/com/mewna/catnip/util/SafeVertxCompletableFuture.java
@@ -34,9 +34,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
 import java.util.concurrent.*;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 @SuppressWarnings("WeakerAccess")
@@ -64,6 +61,70 @@ public class SafeVertxCompletableFuture<T> extends CompletableFuture<T> {
                 complete(res);
             }
         });
+    }
+    
+    public SafeVertxCompletableFuture<T> withContext() {
+        final Context context = Vertx.currentContext();
+        return withContext(context);
+    }
+    
+    public SafeVertxCompletableFuture<T> withContext(final Context context) {
+        final SafeVertxCompletableFuture<T> future = new SafeVertxCompletableFuture<>(catnip, context);
+        whenComplete((res, err) -> {
+            if(err != null) {
+                future.completeExceptionally(err);
+            } else {
+                future.complete(res);
+            }
+        });
+        return future;
+    }
+    
+    public Context context() {
+        return context;
+    }
+    
+    @Override
+    public Executor defaultExecutor() {
+        return executor;
+    }
+    
+    @Override
+    public SafeVertxCompletableFuture<T> toCompletableFuture() {
+        return this;
+    }
+    
+    @Override
+    public <U> CompletableFuture<U> newIncompleteFuture() {
+        return new SafeVertxCompletableFuture<>(catnip, context);
+    }
+    
+    @Override
+    public CompletionStage<T> minimalCompletionStage() {
+        return copy();
+    }
+    
+    @Override
+    public CompletableFuture<T> copy() {
+        return thenApply(Function.identity());
+    }
+    
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        checkBlock();
+        return super.get();
+    }
+    
+    @Override
+    public T get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        checkBlock();
+        return super.get(timeout, unit);
+    }
+    
+    @Override
+    public T join() {
+        checkBlock();
+        return super.join();
     }
     
     public static <T> SafeVertxCompletableFuture<T> from(final Catnip catnip, final CompletionStage<T> future) {
@@ -116,235 +177,6 @@ public class SafeVertxCompletableFuture<T> extends CompletableFuture<T> {
     public static SafeVertxCompletableFuture<Object> anyOf(final Catnip catnip, final Context context, final CompletableFuture<?>... futures) {
         final CompletableFuture<Object> all = CompletableFuture.anyOf(futures);
         return from(catnip, context, all);
-    }
-    
-    public SafeVertxCompletableFuture<T> withContext() {
-        final Context context = Vertx.currentContext();
-        return withContext(context);
-    }
-    
-    public SafeVertxCompletableFuture<T> withContext(final Context context) {
-        final SafeVertxCompletableFuture<T> future = new SafeVertxCompletableFuture<>(catnip, context);
-        whenComplete((res, err) -> {
-            if(err != null) {
-                future.completeExceptionally(err);
-            } else {
-                future.complete(res);
-            }
-        });
-        return future;
-    }
-    
-    public Context context() {
-        return context;
-    }
-    
-    // ============= Composite Future implementation =============
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> thenApply(final Function<? super T, ? extends U> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenApply(fn));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> thenApplyAsync(final Function<? super T, ? extends U> fn, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenApplyAsync(fn, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> thenAcceptAsync(final Consumer<? super T> action, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenAcceptAsync(action, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> thenRun(final Runnable action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenRun(action));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> thenRunAsync(final Runnable action, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenRunAsync(action, executor));
-    }
-    
-    @Override
-    public <U, V> SafeVertxCompletableFuture<V> thenCombine(final CompletionStage<? extends U> other, final BiFunction<? super T, ? super U, ? extends V> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenCombine(other, fn));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<Void> thenAcceptBoth(final CompletionStage<? extends U> other, final BiConsumer<? super T, ? super U> action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenAcceptBoth(other, action));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<Void> thenAcceptBothAsync(final CompletionStage<? extends U> other, final BiConsumer<? super T, ? super U> action, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenAcceptBothAsync(other, action, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> runAfterBoth(final CompletionStage<?> other, final Runnable action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.runAfterBoth(other, action));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> runAfterBothAsync(final CompletionStage<?> other, final Runnable action, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.runAfterBothAsync(other, action, executor));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> applyToEither(final CompletionStage<? extends T> other, final Function<? super T, U> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.applyToEither(other, fn));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> applyToEitherAsync(final CompletionStage<? extends T> other, final Function<? super T, U> fn, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.applyToEitherAsync(other, fn, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> acceptEither(final CompletionStage<? extends T> other, final Consumer<? super T> action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.acceptEither(other, action));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> acceptEitherAsync(final CompletionStage<? extends T> other, final Consumer<? super T> action, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.acceptEitherAsync(other, action, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> runAfterEither(final CompletionStage<?> other, final Runnable action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.runAfterEither(other, action));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> runAfterEitherAsync(final CompletionStage<?> other, final Runnable action, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.runAfterEitherAsync(other, action, executor));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> thenCompose(final Function<? super T, ? extends CompletionStage<U>> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenCompose(fn));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<T> whenComplete(final BiConsumer<? super T, ? super Throwable> action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.whenComplete(action));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<T> whenCompleteAsync(final BiConsumer<? super T, ? super Throwable> action, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.whenCompleteAsync(action, executor));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> handle(final BiFunction<? super T, Throwable, ? extends U> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.handle(fn));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> handleAsync(final BiFunction<? super T, Throwable, ? extends U> fn, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.handleAsync(fn, executor));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> thenApplyAsync(final Function<? super T, ? extends U> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenApplyAsync(fn, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> thenAccept(final Consumer<? super T> action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenAccept(action));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> thenAcceptAsync(final Consumer<? super T> action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenAcceptAsync(action, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> thenRunAsync(final Runnable action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenRunAsync(action, executor));
-    }
-    
-    @Override
-    public <U, V> SafeVertxCompletableFuture<V> thenCombineAsync(final CompletionStage<? extends U> other,
-                                                                 final BiFunction<? super T, ? super U, ? extends V> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenCombineAsync(other, fn, executor));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<Void> thenAcceptBothAsync(final CompletionStage<? extends U> other,
-                                                                    final BiConsumer<? super T, ? super U> action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenAcceptBothAsync(other, action, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> runAfterBothAsync(final CompletionStage<?> other, final Runnable action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.runAfterBothAsync(other, action, executor));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> applyToEitherAsync(final CompletionStage<? extends T> other, final Function<? super T, U> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.applyToEitherAsync(other, fn, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> acceptEitherAsync(final CompletionStage<? extends T> other, final Consumer<? super T> action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.acceptEitherAsync(other, action, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<Void> runAfterEitherAsync(final CompletionStage<?> other, final Runnable action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.runAfterEitherAsync(other, action, executor));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> thenComposeAsync(final Function<? super T, ? extends CompletionStage<U>> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenComposeAsync(fn, executor));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> thenComposeAsync(final Function<? super T, ? extends CompletionStage<U>> fn, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenComposeAsync(fn, executor));
-    }
-    
-    public <U, V> SafeVertxCompletableFuture<V> thenCombineAsync(
-            final CompletionStage<? extends U> other,
-            final BiFunction<? super T, ? super U, ? extends V> fn, final Executor executor) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.thenCombineAsync(other, fn, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<T> whenCompleteAsync(final BiConsumer<? super T, ? super Throwable> action) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.whenCompleteAsync(action, executor));
-    }
-    
-    @Override
-    public <U> SafeVertxCompletableFuture<U> handleAsync(final BiFunction<? super T, Throwable, ? extends U> fn) {
-        return new SafeVertxCompletableFuture<>(catnip, context, super.handleAsync(fn, executor));
-    }
-    
-    @Override
-    public SafeVertxCompletableFuture<T> toCompletableFuture() {
-        return this;
-    }
-    
-    @Override
-    public T get() throws InterruptedException, ExecutionException {
-        checkBlock();
-        return super.get();
-    }
-    
-    @Override
-    public T get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        checkBlock();
-        return super.get(timeout, unit);
-    }
-    
-    @Override
-    public T join() {
-        checkBlock();
-        return super.join();
     }
     
     private void complete(final T result, final Throwable error) {


### PR DESCRIPTION
Even though we're getting rid of vertx, this class can still be used to protect whatever event loop we use