### PR TITLE
Initial implementation of new channel types

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,7 +6,7 @@
     <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true" />
     <option name="JD_ADD_BLANK_AFTER_RETURN" value="true" />
     <option name="FORMATTER_TAGS_ENABLED" value="true" />
-    <JSCodeStyleSettings version="0">
+    <JSCodeStyleSettings>
       <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
     </JSCodeStyleSettings>
     <JavaCodeStyleSettings>

--- a/src/main/java/com/mewna/catnip/entity/channel/Channel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/Channel.java
@@ -29,7 +29,6 @@ package com.mewna.catnip.entity.channel;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.mewna.catnip.entity.Snowflake;
 import com.mewna.catnip.entity.util.Permission;
 import com.mewna.catnip.util.PermissionUtil;
@@ -150,6 +149,12 @@ public interface Channel extends Snowflake {
         return !type().isGuild();
     }
     
+    @JsonIgnore
+    @CheckReturnValue
+    default boolean isNews() {
+        return type() == ChannelType.NEWS;
+    }
+    
     /**
      * @return This channel instance as a {@link GuildChannel}.
      */
@@ -264,7 +269,17 @@ public interface Channel extends Snowflake {
         /**
          * A guild channel category with zero or more child channels.
          */
-        CATEGORY(4, true);
+        CATEGORY(4, true),
+        /**
+         * A news channel in a guild. See discordapp/discord-api-docs#881
+         */
+        NEWS(5, true),
+        /**
+         * A store channel in a guild. Used for literally what it sounds like.
+         * Requires an application with a valid SKU. Not officially announced,
+         * but there is some discussion about it in discordapp/discord-api-docs#881.
+         */
+        STORE(6, true);
         
         @Getter
         private final int key;

--- a/src/main/java/com/mewna/catnip/entity/channel/Channel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/Channel.java
@@ -29,6 +29,7 @@ package com.mewna.catnip.entity.channel;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.mewna.catnip.entity.Snowflake;
 import com.mewna.catnip.entity.util.Permission;
 import com.mewna.catnip.util.PermissionUtil;
@@ -47,7 +48,7 @@ import java.util.concurrent.CompletionStage;
  * @since 9/12/18
  */
 @SuppressWarnings({"ClassReferencesSubclass", "unused"})
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonTypeInfo(use = Id.CLASS)
 public interface Channel extends Snowflake {
     /**
      * @return The type of this channel.
@@ -149,10 +150,23 @@ public interface Channel extends Snowflake {
         return !type().isGuild();
     }
     
+    /**
+     * Whether or not this channel is a news channel. See discordapp/discord-api-docs#881.
+     */
     @JsonIgnore
     @CheckReturnValue
     default boolean isNews() {
         return type() == ChannelType.NEWS;
+    }
+    
+    /**
+     * Whether or not this channel is a store channel. See discordapp/discord-api-docs#881
+     * and discordapp/discord-api-docs#889.
+     */
+    @JsonIgnore
+    @CheckReturnValue
+    default boolean isStore() {
+        return type() == ChannelType.STORE;
     }
     
     /**

--- a/src/main/java/com/mewna/catnip/entity/channel/NewsChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/NewsChannel.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 amy, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.mewna.catnip.entity.channel;
+
+/**
+ * A news channel in a guild is effectively a reskinned text channel, but with
+ * two important differences:
+ * <ol>
+ * <li>The channel type is {@link ChannelType#NEWS}.</li>
+ * <li>There is no ratelimit.</li>
+ * </ol>
+ *
+ * @author amy
+ * @since 3/10/19.
+ */
+public interface NewsChannel extends TextChannel {
+    @Override
+    default int rateLimitPerUser() {
+        return 0;
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/channel/StoreChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/StoreChannel.java
@@ -25,66 +25,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.mewna.catnip.entity.impl;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.mewna.catnip.Catnip;
-import com.mewna.catnip.entity.RequiresCatnip;
-import com.mewna.catnip.entity.channel.NewsChannel;
-import com.mewna.catnip.entity.channel.TextChannel;
-import com.mewna.catnip.entity.guild.PermissionOverride;
-import lombok.*;
-import lombok.experimental.Accessors;
+package com.mewna.catnip.entity.channel;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 
 /**
- * TODO: Should this just extend {@link TextChannelImpl} instead?
- *
  * @author amy
- * @since 3/10/19.
+ * @since 3/14/19.
  */
-@Getter(onMethod_ = @JsonProperty)
-@Setter(onMethod_ = @JsonProperty)
-@Builder
-@Accessors(fluent = true)
-@NoArgsConstructor
-@AllArgsConstructor
-public class NewsChannelImpl implements NewsChannel, RequiresCatnip {
-    private transient Catnip catnip;
-    
-    private long idAsLong;
-    private String name;
-    private long guildIdAsLong;
-    private int position;
-    private long parentIdAsLong;
-    private List<PermissionOverride> overrides;
-    private String topic;
-    private boolean nsfw;
-    
+public interface StoreChannel extends GuildChannel {
+    @Nonnull
     @Override
-    public void catnip(@Nonnull final Catnip catnip) {
-        this.catnip = catnip;
-        for(final PermissionOverride override : overrides) {
-            if(override instanceof RequiresCatnip) {
-                ((RequiresCatnip) override).catnip(catnip);
-            }
-        }
+    default ChannelType type() {
+        return ChannelType.STORE;
     }
     
-    @Override
-    public int hashCode() {
-        return Long.hashCode(idAsLong);
-    }
-    
-    @Override
-    public boolean equals(final Object obj) {
-        return obj instanceof TextChannel && ((TextChannel) obj).idAsLong() == idAsLong;
-    }
-    
-    @Override
-    public String toString() {
-        return String.format("NewsChannel (%s)", name);
-    }
+    boolean nsfw();
 }

--- a/src/main/java/com/mewna/catnip/entity/channel/TextChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/TextChannel.java
@@ -86,7 +86,14 @@ public interface TextChannel extends GuildChannel, MessageChannel, Mentionable {
     @JsonIgnore
     @CheckReturnValue
     default boolean isText() {
-        return true;
+        return type() == ChannelType.TEXT;
+    }
+    
+    @Override
+    @JsonIgnore
+    @CheckReturnValue
+    default boolean isNews() {
+        return type() == ChannelType.NEWS;
     }
     
     @Override

--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -272,6 +272,23 @@ public final class EntityBuilder {
     
     @Nonnull
     @CheckReturnValue
+    public NewsChannel createNewsChannel(@Nonnull final String guildId, @Nonnull final JsonObject data) {
+        final String parentId = data.getString("parent_id");
+        return NewsChannelImpl.builder()
+                .catnip(catnip)
+                .idAsLong(Long.parseUnsignedLong(data.getString("id")))
+                .name(data.getString("name"))
+                .guildIdAsLong(Long.parseUnsignedLong(guildId))
+                .position(data.getInteger("position", -1))
+                .parentIdAsLong(parentId == null ? 0 : Long.parseUnsignedLong(parentId))
+                .overrides(toList(data.getJsonArray("permission_overwrites"), this::createPermissionOverride))
+                .topic(data.getString("topic"))
+                .nsfw(data.getBoolean("nsfw", false))
+                .build();
+    }
+    
+    @Nonnull
+    @CheckReturnValue
     public VoiceChannel createVoiceChannel(@Nonnull final String guildId, @Nonnull final JsonObject data) {
         final String parentId = data.getString("parent_id");
         return VoiceChannelImpl.builder()
@@ -340,6 +357,8 @@ public final class EntityBuilder {
                 return createVoiceChannel(guildId, data);
             case CATEGORY:
                 return createCategory(guildId, data);
+            case NEWS:
+                return createNewsChannel(guildId, data);
             default:
                 throw new UnsupportedOperationException("Unsupported channel type " + type);
         }

--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -364,16 +364,24 @@ public final class EntityBuilder {
     public GuildChannel createGuildChannel(@Nonnull final String guildId, @Nonnull final JsonObject data) {
         final ChannelType type = ChannelType.byKey(data.getInteger("type"));
         switch(type) {
-            case TEXT:
+            case TEXT: {
                 return createTextChannel(guildId, data);
-            case VOICE:
+            }
+            case VOICE: {
                 return createVoiceChannel(guildId, data);
-            case CATEGORY:
+            }
+            case CATEGORY: {
                 return createCategory(guildId, data);
-            case NEWS:
+            }
+            case NEWS: {
                 return createNewsChannel(guildId, data);
-            default:
+            }
+            case STORE: {
+                return createStoreChannel(guildId, data);
+            }
+            default: {
                 throw new UnsupportedOperationException("Unsupported channel type " + type);
+            }
         }
     }
     
@@ -828,7 +836,7 @@ public final class EntityBuilder {
         if(guildId != null) {
             mentionedMembers.addAll(toList(data.getJsonArray("mentions"), o -> createPartialMemberMention(guildId, o)));
         }
-    
+        
         //noinspection ConstantConditions
         return MessageImpl.builder()
                 .catnip(catnip)

--- a/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/EntityBuilder.java
@@ -286,6 +286,22 @@ public final class EntityBuilder {
     
     @Nonnull
     @CheckReturnValue
+    public StoreChannel createStoreChannel(@Nonnull final String guildId, @Nonnull final JsonObject data) {
+        final String parentId = data.getString("parent_id");
+        return StoreChannelImpl.builder()
+                .catnip(catnip)
+                .idAsLong(Long.parseUnsignedLong(data.getString("id")))
+                .name(data.getString("name"))
+                .guildIdAsLong(Long.parseUnsignedLong(guildId))
+                .position(data.getInteger("position", -1))
+                .parentIdAsLong(parentId == null ? 0 : Long.parseUnsignedLong(parentId))
+                .overrides(toList(data.getJsonArray("permission_overwrites"), this::createPermissionOverride))
+                .nsfw(data.getBoolean("nsfw", false))
+                .build();
+    }
+    
+    @Nonnull
+    @CheckReturnValue
     public VoiceChannel createVoiceChannel(@Nonnull final String guildId, @Nonnull final JsonObject data) {
         final String parentId = data.getString("parent_id");
         return VoiceChannelImpl.builder()

--- a/src/main/java/com/mewna/catnip/entity/impl/NewsChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/NewsChannelImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019 amy, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.mewna.catnip.entity.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mewna.catnip.Catnip;
+import com.mewna.catnip.entity.RequiresCatnip;
+import com.mewna.catnip.entity.channel.NewsChannel;
+import com.mewna.catnip.entity.channel.TextChannel;
+import com.mewna.catnip.entity.guild.PermissionOverride;
+import lombok.*;
+import lombok.experimental.Accessors;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * TODO: Should this just extend {@link TextChannelImpl} instead?
+ *
+ * @author amy
+ * @since 3/10/19.
+ */
+@Getter(onMethod_ = @JsonProperty)
+@Setter(onMethod_ = @JsonProperty)
+@Builder
+@Accessors(fluent = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsChannelImpl implements NewsChannel, RequiresCatnip {
+    private transient Catnip catnip;
+    
+    private long idAsLong;
+    private String name;
+    private long guildIdAsLong;
+    private int position;
+    private long parentIdAsLong;
+    private List<PermissionOverride> overrides;
+    private String topic;
+    private boolean nsfw;
+    
+    @Override
+    public void catnip(@Nonnull final Catnip catnip) {
+        this.catnip = catnip;
+        for(final PermissionOverride override : overrides) {
+            if(override instanceof RequiresCatnip) {
+                ((RequiresCatnip) override).catnip(catnip);
+            }
+        }
+    }
+    
+    @Override
+    public int hashCode() {
+        return Long.hashCode(idAsLong);
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof TextChannel && ((TextChannel) obj).idAsLong() == idAsLong;
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("TextChannel (%s)", name);
+    }
+}

--- a/src/main/java/com/mewna/catnip/entity/impl/StoreChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/StoreChannelImpl.java
@@ -30,7 +30,7 @@ package com.mewna.catnip.entity.impl;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mewna.catnip.Catnip;
 import com.mewna.catnip.entity.RequiresCatnip;
-import com.mewna.catnip.entity.channel.NewsChannel;
+import com.mewna.catnip.entity.channel.StoreChannel;
 import com.mewna.catnip.entity.channel.TextChannel;
 import com.mewna.catnip.entity.guild.PermissionOverride;
 import lombok.*;
@@ -40,10 +40,8 @@ import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
- * TODO: Should this just extend {@link TextChannelImpl} instead?
- *
  * @author amy
- * @since 3/10/19.
+ * @since 3/14/19.
  */
 @Getter(onMethod_ = @JsonProperty)
 @Setter(onMethod_ = @JsonProperty)
@@ -51,7 +49,7 @@ import java.util.List;
 @Accessors(fluent = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class NewsChannelImpl implements NewsChannel, RequiresCatnip {
+public class StoreChannelImpl implements StoreChannel, RequiresCatnip {
     private transient Catnip catnip;
     
     private long idAsLong;
@@ -60,7 +58,6 @@ public class NewsChannelImpl implements NewsChannel, RequiresCatnip {
     private int position;
     private long parentIdAsLong;
     private List<PermissionOverride> overrides;
-    private String topic;
     private boolean nsfw;
     
     @Override
@@ -85,6 +82,6 @@ public class NewsChannelImpl implements NewsChannel, RequiresCatnip {
     
     @Override
     public String toString() {
-        return String.format("NewsChannel (%s)", name);
+        return String.format("StoreChannel (%s)", name);
     }
 }


### PR DESCRIPTION
Will close #267 

A couple things to consider before merging:
- Do we REALLY need the new `NewsChannel` type? We could probably get away with just an `isNews()` and `TextChannel` returning the right thing for type / ratelimits
- Does the default in-memory cache handle this right? How can we even test this?
- How will we handle store channels (type 6)?