### PR TITLE
Adding youtu.be to the meme

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/message/Message.java
+++ b/src/main/java/com/mewna/catnip/entity/message/Message.java
@@ -372,7 +372,7 @@ public interface Message extends Snowflake {
     
     @JsonIgnore
     default boolean isRickRoll() {
-        return content().contains("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+        return content().contains("https://www.youtube.com/watch?v=dQw4w9WgXcQ") || content().contains("https://youtu.be/dQw4w9WgXcQ");
     }
     
     @JsonDeserialize(as = AttachmentImpl.class)


### PR DESCRIPTION
Innocent users could still be trolled using the rick roll if the troller used https://youtu.be/dQw4w9WgXcQ instead of https://www.youtube.com/watch?v=dQw4w9WgXcQ.
This commit fixes that