### PR TITLE
Add basic Rx2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,11 @@ where `JsonPojoCodec` is `com.mewna.catnip.util.JsonPojoCodec` and is safe to us
   https://github.com/natanbc/catnip-voice
 - `catnip-utilities` - Some extensions for typesafe commands, event waiters, reaction menus, 
   and more. https://github.com/queer/catnip-utilities 
-- `catnip-rxjava2` - RxJava 2 Observable support for catnip. 
-  https://github.com/queer/catnip-rxjava2
 
 ## Why write a fourth Java lib?
 
 - JDA is very nice, but doesn't allow for as much freedom with customizing the internals;
   it's more / less "do it this way or use another lib" in my experience.
-- Discord4J is built on [Project Reactor](https://projectreactor.io/); I wanted to be able 
-  to choose a reactive:tm: implementation (callbacks vs. coroutines vs. reactive-streams vs.
-  rx vs. ...) to use with the lib and not be stuck with just one.
 - I didn't want ten billion events for every possible case. catnip maps more/less 1:1 with the
   Discord API, and any "extra" events on top of that need to be user-provided via extensions or
   other means. I guess really I just didn't want my lib to be as "high-level" as other libs are.
@@ -145,13 +140,8 @@ where `JsonPojoCodec` is `com.mewna.catnip.util.JsonPojoCodec` and is safe to us
 ### Why vert.x?
 
 - vert.x is nice and reactive and async. :tm:
-- You can use callbacks (like we do), but vert.x also provides support for reactive streams, Rx,
+- You can use callbacks or Rx (like we do), but vert.x also provides support for reactive streams
   and kotlin coroutines.
 - There's a *lot* of [vert.x libraries and documentation](https://vertx.io/docs/) for just about
   anything you want.
 - The reactive, event-loop-driven model fits well for a Discord bot use-case.
-
-## Real-world numbers?
-
-With a bot in ~35k guilds, catnip used ~1.5GB of RAM and <10% CPU on a 2c/4gb VM.
-Sorry, I lost the screenshots :<

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>vertx-core</artifactId>
             <version>${vertx.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-rx-java2</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
 
         <!--
         vert.x is retarded for multipart, so we use this instead

--- a/src/main/java/com/mewna/catnip/Catnip.java
+++ b/src/main/java/com/mewna/catnip/Catnip.java
@@ -50,11 +50,13 @@ import com.mewna.catnip.shard.ratelimit.Ratelimiter;
 import com.mewna.catnip.shard.session.SessionManager;
 import com.mewna.catnip.util.Utils;
 import com.mewna.catnip.util.logging.LogAdapter;
+import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.FlowableHelper;
 import io.vertx.reactivex.ObservableHelper;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -711,6 +713,18 @@ public interface Catnip {
     }
     
     /**
+     * Add a reactive stream handler for events of the given type.
+     *
+     * @param type The type of event to stream.
+     * @param <T>  The object type of the event being streamed.
+     *
+     * @return The flowable.
+     */
+    default <T> Flowable<T> flow(@Nonnull final EventType<T> type) {
+        return FlowableHelper.toFlowable(on(type).bodyStream());
+    }
+    
+    /**
      * Add a consumer for the specified event type with the given handler
      * callback.
      *
@@ -738,6 +752,32 @@ public interface Catnip {
     default <T, E> MessageConsumer<Pair<T, E>> on(@Nonnull final DoubleEventType<T, E> type,
                                                   @Nonnull final BiConsumer<T, E> handler) {
         return on(type).handler(m -> handler.accept(m.body().getLeft(), m.body().getRight()));
+    }
+    
+    /**
+     * Add a reactive stream handler for events of the given type.
+     *
+     * @param type The type of event to stream.
+     * @param <T>  The object type of the event being streamed.
+     * @param <E>  The object type of the event being streamed.
+     *
+     * @return The observable.
+     */
+    default <T, E> Observable<Pair<T, E>> observe(@Nonnull final DoubleEventType<T, E> type) {
+        return ObservableHelper.toObservable(on(type).bodyStream());
+    }
+    
+    /**
+     * Add a reactive stream handler for events of the given type.
+     *
+     * @param type The type of event to stream.
+     * @param <T>  The object type of the event being streamed.
+     * @param <E>  The object type of the event being streamed.
+     *
+     * @return The flowable.
+     */
+    default <T, E> Flowable<Pair<T, E>> flow(@Nonnull final DoubleEventType<T, E> type) {
+        return FlowableHelper.toFlowable(on(type).bodyStream());
     }
     
     /**

--- a/src/main/java/com/mewna/catnip/Catnip.java
+++ b/src/main/java/com/mewna/catnip/Catnip.java
@@ -50,10 +50,12 @@ import com.mewna.catnip.shard.ratelimit.Ratelimiter;
 import com.mewna.catnip.shard.session.SessionManager;
 import com.mewna.catnip.util.Utils;
 import com.mewna.catnip.util.logging.LogAdapter;
+import io.reactivex.Observable;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.ObservableHelper;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.CheckReturnValue;
@@ -689,6 +691,18 @@ public interface Catnip {
      */
     default <T> MessageConsumer<T> on(@Nonnull final EventType<T> type, @Nonnull final Consumer<T> handler) {
         return on(type).handler(m -> handler.accept(m.body()));
+    }
+    
+    /**
+     * Add a reactive stream handler for events of the given type.
+     *
+     * @param type The type of event to stream.
+     * @param <T>  The object type of the event being streamed.
+     *
+     * @return The observable.
+     */
+    default <T> Observable<T> observe(@Nonnull final EventType<T> type) {
+        return ObservableHelper.toObservable(on(type).bodyStream());
     }
     
     /**


### PR DESCRIPTION
It has been argued that catnip doesn't really count as reactive, and after looking things over, I honestly have to agree with this. This PR is made to make catnip actually properly reactive like it was supposed to be since the beginning. Rx2 is used here because vert.x's support for reactive-streams is terrible it seems :(

This PR would lead to calling catnip a "fully-async, *optionally-reactive*" library.

- [x] Add `Observable`/`Flowable` variant of `Catnip#on` for gateway events

To explore in a future PR:
- Add a proxy or something to wrap REST calls in `Observable` variants
- Make the ratelimiter actually use Rx internally