### PR TITLE
Include channel type in serialized entity data

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/channel/Category.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/Category.java
@@ -37,12 +37,6 @@ import javax.annotation.Nonnull;
  * @since 9/12/18
  */
 public interface Category extends GuildChannel {
-    @Nonnull
-    @Override
-    default ChannelType type() {
-        return ChannelType.CATEGORY;
-    }
-    
     @Override
     @CheckReturnValue
     default boolean isText() {

--- a/src/main/java/com/mewna/catnip/entity/channel/GroupDMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/GroupDMChannel.java
@@ -45,12 +45,6 @@ import java.util.List;
 @SuppressWarnings("unused")
 @JsonDeserialize(as = GroupDMChannelImpl.class)
 public interface GroupDMChannel extends DMChannel {
-    @Nonnull
-    @Override
-    default ChannelType type() {
-        return ChannelType.GROUP_DM;
-    }
-    
     /**
      * @return The list of users in the group DM.
      */

--- a/src/main/java/com/mewna/catnip/entity/channel/TextChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/TextChannel.java
@@ -50,12 +50,6 @@ import java.util.concurrent.CompletionStage;
 @SuppressWarnings("unused")
 @JsonDeserialize(as = TextChannelImpl.class)
 public interface TextChannel extends GuildChannel, MessageChannel, Mentionable {
-    @Nonnull
-    @Override
-    default ChannelType type() {
-        return ChannelType.TEXT;
-    }
-    
     /**
      * The channel's topic. Shown at the top of the channel. May be
      * {@code null}.

--- a/src/main/java/com/mewna/catnip/entity/channel/UserDMChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/UserDMChannel.java
@@ -44,12 +44,6 @@ import javax.annotation.Nullable;
  */
 @JsonDeserialize(as = UserDMChannelImpl.class)
 public interface UserDMChannel extends DMChannel {
-    @Nonnull
-    @Override
-    default ChannelType type() {
-        return ChannelType.DM;
-    }
-    
     @Nullable
     @CheckReturnValue
     User recipient();

--- a/src/main/java/com/mewna/catnip/entity/channel/VoiceChannel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/VoiceChannel.java
@@ -42,12 +42,6 @@ import javax.annotation.Nonnull;
  */
 @JsonDeserialize(as = VoiceChannelImpl.class)
 public interface VoiceChannel extends GuildChannel {
-    @Nonnull
-    @Override
-    default ChannelType type() {
-        return ChannelType.VOICE;
-    }
-    
     /**
      * @return The bitrate of this channel. Will be from 8 to 96.
      */

--- a/src/main/java/com/mewna/catnip/entity/impl/CategoryImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/CategoryImpl.java
@@ -50,6 +50,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CategoryImpl implements Category, RequiresCatnip {
+    private final ChannelType type = ChannelType.CATEGORY;
+    
     @JsonIgnore
     private transient Catnip catnip;
     

--- a/src/main/java/com/mewna/catnip/entity/impl/GroupDMChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/GroupDMChannelImpl.java
@@ -50,6 +50,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GroupDMChannelImpl implements GroupDMChannel, RequiresCatnip {
+    private final ChannelType type = ChannelType.GROUP_DM;
+    
     @JsonIgnore
     private transient Catnip catnip;
     

--- a/src/main/java/com/mewna/catnip/entity/impl/NewsChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/NewsChannelImpl.java
@@ -27,6 +27,7 @@
 
 package com.mewna.catnip.entity.impl;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mewna.catnip.Catnip;
 import com.mewna.catnip.entity.RequiresCatnip;
@@ -52,6 +53,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NewsChannelImpl implements NewsChannel, RequiresCatnip {
+    private final ChannelType type = ChannelType.NEWS;
+    
+    @JsonIgnore
     private transient Catnip catnip;
     
     private long idAsLong;

--- a/src/main/java/com/mewna/catnip/entity/impl/StoreChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/StoreChannelImpl.java
@@ -50,6 +50,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StoreChannelImpl implements StoreChannel, RequiresCatnip {
+    private final ChannelType type = ChannelType.STORE;
+    
     private transient Catnip catnip;
     
     private long idAsLong;

--- a/src/main/java/com/mewna/catnip/entity/impl/TextChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/TextChannelImpl.java
@@ -49,6 +49,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TextChannelImpl implements TextChannel, RequiresCatnip {
+    private final ChannelType type = ChannelType.TEXT;
+    
     private transient Catnip catnip;
     
     private long idAsLong;

--- a/src/main/java/com/mewna/catnip/entity/impl/UserDMChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/UserDMChannelImpl.java
@@ -50,6 +50,8 @@ import javax.annotation.Nullable;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserDMChannelImpl implements UserDMChannel, RequiresCatnip {
+    private final ChannelType type = ChannelType.DM;
+    
     @JsonIgnore
     private transient Catnip catnip;
     

--- a/src/main/java/com/mewna/catnip/entity/impl/VoiceChannelImpl.java
+++ b/src/main/java/com/mewna/catnip/entity/impl/VoiceChannelImpl.java
@@ -50,6 +50,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class VoiceChannelImpl implements VoiceChannel, RequiresCatnip {
+    private final ChannelType type = ChannelType.VOICE;
+    
+    
     @JsonIgnore
     private transient Catnip catnip;
     


### PR DESCRIPTION
Just adds the `type` field to channel entities. Will close #318. 