### PR TITLE
Add Channel#isGuildMessageChannel utility method

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/channel/Channel.java
+++ b/src/main/java/com/mewna/catnip/entity/channel/Channel.java
@@ -168,6 +168,15 @@ public interface Channel extends Snowflake {
     default boolean isStore() {
         return type() == ChannelType.STORE;
     }
+
+    /**
+     * @return Whether or not this channel is part of a guild and can contain messages.
+     */
+    @JsonIgnore
+    @CheckReturnValue
+    default boolean isGuildMessageChannel() {
+        return isText() || isNews();
+    }
     
     /**
      * @return This channel instance as a {@link GuildChannel}.


### PR DESCRIPTION
A little method which allows to check if a guild channel can accept messages.