### PR TITLE
Extension, CatnipShard and LogAdaptor changes.

### DIFF
--- a/src/main/java/com/mewna/catnip/extension/Extension.java
+++ b/src/main/java/com/mewna/catnip/extension/Extension.java
@@ -36,6 +36,7 @@ import io.reactivex.Completable;
 import javax.annotation.Nonnull;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * <strong>If you are unsure if you need to implement this interface, you
@@ -121,6 +122,13 @@ public interface Extension {
      *
      * @return The extension instance.
      */
+    default Extension injectOptions(@Nonnull final UnaryOperator<CatnipOptions> optionsPatcher) {
+        // This is only temporary so any classes that may happen to be extending
+        // the now deprecated method can move over at their own pace.
+        return injectOptions((Function<CatnipOptions, CatnipOptions>) optionsPatcher);
+    }
+    
+    @Deprecated
     default Extension injectOptions(@Nonnull final Function<CatnipOptions, CatnipOptions> optionsPatcher) {
         catnip().injectOptions(this, optionsPatcher);
         return this;

--- a/src/main/java/com/mewna/catnip/extension/hook/CatnipHook.java
+++ b/src/main/java/com/mewna/catnip/extension/hook/CatnipHook.java
@@ -30,6 +30,7 @@ package com.mewna.catnip.extension.hook;
 import com.grack.nanojson.JsonObject;
 import com.mewna.catnip.rest.ResponsePayload;
 import com.mewna.catnip.rest.Routes.Route;
+import com.mewna.catnip.shard.ShardInfo;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -76,6 +77,24 @@ public interface CatnipHook {
      */
     default JsonObject rawGatewaySendHook(@Nonnull final JsonObject json) {
         return json;
+    }
+    
+    /**
+     * Called when the websocket is opened. The default behaviour is to do nothing.
+     *
+     * @param shard The shard of the socket.
+     */
+    default void rawGatewayOpenHook(@Nonnull final ShardInfo shard) {
+    }
+    
+    /**
+     * Called when the websocket is closed. The default behaviour is to do nothing.
+     *
+     * @param shard  The shard of the socket.
+     * @param code   The close code.
+     * @param reason The reason for closing.
+     */
+    default void rawGatewayCloseHook(@Nonnull final ShardInfo shard, final int code, @Nonnull final String reason) {
     }
     
     /**

--- a/src/main/java/com/mewna/catnip/shard/ShardInfo.java
+++ b/src/main/java/com/mewna/catnip/shard/ShardInfo.java
@@ -39,4 +39,8 @@ import lombok.Getter;
 public class ShardInfo {
     private final int id;
     private final int limit;
+    
+    public String toString() {
+        return id + "/" + limit;
+    }
 }

--- a/src/main/java/com/mewna/catnip/util/logging/DefaultLogAdapter.java
+++ b/src/main/java/com/mewna/catnip/util/logging/DefaultLogAdapter.java
@@ -37,7 +37,7 @@ import org.slf4j.helpers.MessageFormatter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.StackWalker.Option;
-import java.util.Set;
+import java.util.Collections;
 
 /**
  * @author amy
@@ -45,8 +45,7 @@ import java.util.Set;
  */
 @Accessors(fluent = true)
 public class DefaultLogAdapter implements LogAdapter {
-    private final StackWalker stackWalker = StackWalker.getInstance(Set.of(Option.SHOW_REFLECT_FRAMES,
-            Option.RETAIN_CLASS_REFERENCE));
+    private final StackWalker stackWalker = StackWalker.getInstance(Collections.singleton(Option.RETAIN_CLASS_REFERENCE));
     
     @Override
     public void log(@Nonnull final Level level, @Nonnull final String message, @Nullable final Object... objects) {


### PR DESCRIPTION
Added raw gateway open and close events to CatnipHook.
Extensions uses Unary Operator in place of Function with a fallback for extending classes
CatnipShard variables `id` and `total` and method `shardInfo()` replaced with shardInfo variable.
DefaultLogAdaptor#stackWalker no longer shows reflection frames, although this should never happen in practice regardless.