### PR TITLE
Convert routes to :params instead of {params}

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,8 +3,6 @@
     <option name="GENERATE_FINAL_LOCALS" value="true" />
     <option name="GENERATE_FINAL_PARAMETERS" value="true" />
     <option name="RIGHT_MARGIN" value="126" />
-    <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true" />
-    <option name="JD_ADD_BLANK_AFTER_RETURN" value="true" />
     <option name="FORMATTER_TAGS_ENABLED" value="true" />
     <JSCodeStyleSettings version="0">
       <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
@@ -24,7 +22,6 @@
           <option value="scalaxy.beans._" />
         </array>
       </option>
-      <option name="USE_SCALADOC2_FORMATTING" value="false" />
     </ScalaCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -58,9 +55,6 @@
       <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="false" />
     </codeStyleSettings>
     <codeStyleSettings language="Scala">
-      <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
-      <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="false" />
-      <option name="SPACE_BEFORE_FOR_PARENTHESES" value="false" />
       <indentOptions>
         <option name="KEEP_INDENTS_ON_EMPTY_LINES" value="true" />
       </indentOptions>

--- a/.idea/inspectionProfiles/Real.xml
+++ b/.idea/inspectionProfiles/Real.xml
@@ -26,6 +26,7 @@
     <inspection_tool class="ConfusingOctalEscape" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantOnLHSOfComparison" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ConstantOnWrongSideOfComparisonMerged" />
     <inspection_tool class="ConstructorCount" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreDeprecatedConstructors" value="false" />
       <option name="m_limit" value="5" />
@@ -70,6 +71,7 @@
     </inspection_tool>
     <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MultipleTypedDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="MultipleVariablesInDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonFinalFieldInEnum" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonFinalUtilityClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ObsoleteCollection" enabled="true" level="WARNING" enabled_by_default="true">

--- a/src/main/java/com/mewna/catnip/rest/Routes.java
+++ b/src/main/java/com/mewna/catnip/rest/Routes.java
@@ -44,89 +44,90 @@ import static com.mewna.catnip.rest.Routes.HttpMethod.*;
 public final class Routes {
     // @formatter:off
     public static final Route GET_GATEWAY_BOT                     = new Route(GET,    "/gateway/bot");
-    public static final Route DELETE_CHANNEL                      = new Route(DELETE, "/channels/{channel.id}", "channel.id");
-    public static final Route GET_CHANNEL                         = new Route(GET,    "/channels/{channel.id}", "channel.id");
-    public static final Route MODIFY_CHANNEL                      = new Route(PATCH,  "/channels/{channel.id}", "channel.id");
-    public static final Route GET_CHANNEL_INVITES                 = new Route(GET,    "/channels/{channel.id}/invites", "channel.id");
-    public static final Route CREATE_CHANNEL_INVITE               = new Route(POST,   "/channels/{channel.id}/invites", "channel.id");
-    public static final Route GET_CHANNEL_MESSAGES                = new Route(GET,    "/channels/{channel.id}/messages", "channel.id");
-    public static final Route CREATE_MESSAGE                      = new Route(POST,   "/channels/{channel.id}/messages", "channel.id");
-    public static final Route BULK_DELETE_MESSAGES                = new Route(POST,   "/channels/{channel.id}/messages/bulk-delete", "channel.id");
-    public static final Route DELETE_MESSAGE                      = new Route(DELETE, "/channels/{channel.id}/messages/{message.id}", "channel.id");
-    public static final Route GET_CHANNEL_MESSAGE                 = new Route(GET,    "/channels/{channel.id}/messages/{message.id}", "channel.id");
-    public static final Route EDIT_MESSAGE                        = new Route(PATCH,  "/channels/{channel.id}/messages/{message.id}", "channel.id");
-    public static final Route DELETE_ALL_REACTIONS                = new Route(DELETE, "/channels/{channel.id}/messages/{message.id}/reactions", "channel.id");
-    public static final Route GET_REACTIONS                       = new Route(GET,    "/channels/{channel.id}/messages/{message.id}/reactions/{emojis}", "channel.id");
-    public static final Route DELETE_OWN_REACTION                 = new Route(DELETE, "/channels/{channel.id}/messages/{message.id}/reactions/{emojis}/@me", "channel.id");
-    public static final Route CREATE_REACTION                     = new Route(PUT,    "/channels/{channel.id}/messages/{message.id}/reactions/{emojis}/@me", "channel.id");
-    public static final Route DELETE_USER_REACTION                = new Route(DELETE, "/channels/{channel.id}/messages/{message.id}/reactions/{emojis}/{user.id}", "channel.id");
-    public static final Route DELETE_CHANNEL_PERMISSION           = new Route(DELETE, "/channels/{channel.id}/permissions/{overwrite.id}", "channel.id");
-    public static final Route EDIT_CHANNEL_PERMISSIONS            = new Route(PUT,    "/channels/{channel.id}/permissions/{overwrite.id}", "channel.id");
-    public static final Route GET_PINNED_MESSAGES                 = new Route(GET,    "/channels/{channel.id}/pins", "channel.id");
-    public static final Route DELETE_PINNED_CHANNEL_MESSAGE       = new Route(DELETE, "/channels/{channel.id}/pins/{message.id}", "channel.id");
-    public static final Route ADD_PINNED_CHANNEL_MESSAGE          = new Route(PUT,    "/channels/{channel.id}/pins/{message.id}", "channel.id");
-    public static final Route TRIGGER_TYPING_INDICATOR            = new Route(POST,   "/channels/{channel.id}/typing", "channel.id");
-    public static final Route GET_CHANNEL_WEBHOOKS                = new Route(GET,    "/channels/{channel.id}/webhooks", "channel.id");
-    public static final Route CREATE_WEBHOOK                      = new Route(POST,   "/channels/{channel.id}/webhooks", "channel.id");
+    public static final Route DELETE_CHANNEL                      = new Route(DELETE, "/channels/:channel", "channel");
+    public static final Route GET_CHANNEL                         = new Route(GET,    "/channels/:channel", "channel");
+    public static final Route MODIFY_CHANNEL                      = new Route(PATCH,  "/channels/:channel", "channel");
+    public static final Route GET_CHANNEL_INVITES                 = new Route(GET,    "/channels/:channel/invites", "channel");
+    public static final Route CREATE_CHANNEL_INVITE               = new Route(POST,   "/channels/:channel/invites", "channel");
+    public static final Route GET_CHANNEL_MESSAGES                = new Route(GET,    "/channels/:channel/messages", "channel");
+    public static final Route CREATE_MESSAGE                      = new Route(POST,   "/channels/:channel/messages", "channel");
+    public static final Route BULK_DELETE_MESSAGES                = new Route(POST,   "/channels/:channel/messages/bulk-delete", "channel");
+    public static final Route DELETE_MESSAGE                      = new Route(DELETE, "/channels/:channel/messages/:message", "channel");
+    public static final Route GET_CHANNEL_MESSAGE                 = new Route(GET,    "/channels/:channel/messages/:message", "channel");
+    public static final Route EDIT_MESSAGE                        = new Route(PATCH,  "/channels/:channel/messages/:message", "channel");
+    public static final Route DELETE_ALL_REACTIONS                = new Route(DELETE, "/channels/:channel/messages/:message/reactions", "channel");
+    public static final Route GET_REACTIONS                       = new Route(GET,    "/channels/:channel/messages/:message/reactions/:emojis", "channel");
+    public static final Route DELETE_OWN_REACTION                 = new Route(DELETE, "/channels/:channel/messages/:message/reactions/:emojis/@me", "channel");
+    public static final Route CREATE_REACTION                     = new Route(PUT,    "/channels/:channel/messages/:message/reactions/:emojis/@me", "channel");
+    public static final Route DELETE_USER_REACTION                = new Route(DELETE, "/channels/:channel/messages/:message/reactions/:emojis/:user", "channel");
+    public static final Route DELETE_CHANNEL_PERMISSION           = new Route(DELETE, "/channels/:channel/permissions/:overwrite", "channel");
+    public static final Route EDIT_CHANNEL_PERMISSIONS            = new Route(PUT,    "/channels/:channel/permissions/:overwrite", "channel");
+    public static final Route GET_PINNED_MESSAGES                 = new Route(GET,    "/channels/:channel/pins", "channel");
+    public static final Route DELETE_PINNED_CHANNEL_MESSAGE       = new Route(DELETE, "/channels/:channel/pins/:message", "channel");
+    public static final Route ADD_PINNED_CHANNEL_MESSAGE          = new Route(PUT,    "/channels/:channel/pins/:message", "channel");
+    public static final Route TRIGGER_TYPING_INDICATOR            = new Route(POST,   "/channels/:channel/typing", "channel");
+    public static final Route GET_CHANNEL_WEBHOOKS                = new Route(GET,    "/channels/:channel/webhooks", "channel");
+    public static final Route CREATE_WEBHOOK                      = new Route(POST,   "/channels/:channel/webhooks", "channel");
     public static final Route CREATE_GUILD                        = new Route(POST,   "/guilds");
-    public static final Route DELETE_GUILD                        = new Route(DELETE, "/guilds/{guild.id}", "guild.id");
-    public static final Route GET_GUILD                           = new Route(GET,    "/guilds/{guild.id}", "guild.id");
-    public static final Route MODIFY_GUILD                        = new Route(PATCH,  "/guilds/{guild.id}", "guild.id");
-    public static final Route GET_GUILD_AUDIT_LOG                 = new Route(GET,    "/guilds/{guild.id}/audit-logs", "guild.id");
-    public static final Route GET_GUILD_BANS                      = new Route(GET,    "/guilds/{guild.id}/bans", "guild.id");
-    public static final Route GET_GUILD_BAN                       = new Route(GET,    "/guilds/{guild.id}/bans/{user.id}", "guild.id");
-    public static final Route REMOVE_GUILD_BAN                    = new Route(DELETE, "/guilds/{guild.id}/bans/{user.id}", "guild.id");
-    public static final Route CREATE_GUILD_BAN                    = new Route(PUT,    "/guilds/{guild.id}/bans/{user.id}", "guild.id");
-    public static final Route GET_GUILD_CHANNELS                  = new Route(GET,    "/guilds/{guild.id}/channels", "guild.id");
-    public static final Route MODIFY_GUILD_CHANNEL_POSITIONS      = new Route(PATCH,  "/guilds/{guild.id}/channels", "guild.id");
-    public static final Route CREATE_GUILD_CHANNEL                = new Route(POST,   "/guilds/{guild.id}/channels", "guild.id");
-    public static final Route GET_GUILD_EMBED                     = new Route(GET,    "/guilds/{guild.id}/embed", "guild.id");
-    public static final Route MODIFY_GUILD_EMBED                  = new Route(PATCH,  "/guilds/{guild.id}/embed", "guild.id");
-    public static final Route LIST_GUILD_EMOJIS                   = new Route(GET,    "/guilds/{guild.id}/emojis", "guild.id");
-    public static final Route GET_GUILD_EMOJI                     = new Route(GET,    "/guilds/{guild.id}/emojis/{emojis.id}", "guild.id");
-    public static final Route CREATE_GUILD_EMOJI                  = new Route(POST,   "/guilds/{guild.id}/emojis", "guild.id");
-    public static final Route MODIFY_GUILD_EMOJI                  = new Route(PATCH,  "/guilds/{guild.id}/emojis/{emojis.id}", "guild.id");
-    public static final Route DELETE_GUILD_EMOJI                  = new Route(DELETE, "/guilds/{guild.id}/emojis/{emojis.id}", "guild.id");
-    public static final Route GET_GUILD_INTEGRATIONS              = new Route(GET,    "/guilds/{guild.id}/integrations", "guild.id");
-    public static final Route CREATE_GUILD_INTEGRATION            = new Route(POST,   "/guilds/{guild.id}/integrations", "guild.id");
-    public static final Route DELETE_GUILD_INTEGRATION            = new Route(DELETE, "/guilds/{guild.id}/integrations/{integration.id}", "guild.id");
-    public static final Route MODIFY_GUILD_INTEGRATION            = new Route(PATCH,  "/guilds/{guild.id}/integrations/{integration.id}", "guild.id");
-    public static final Route SYNC_GUILD_INTEGRATION              = new Route(POST,   "/guilds/{guild.id}/integrations/{integration.id}/sync", "guild.id");
-    public static final Route GET_GUILD_INVITES                   = new Route(GET,    "/guilds/{guild.id}/invites", "guild.id");
-    public static final Route LIST_GUILD_MEMBERS                  = new Route(GET,    "/guilds/{guild.id}/members", "guild.id");
-    public static final Route MODIFY_CURRENT_USERS_NICK           = new Route(PATCH,  "/guilds/{guild.id}/members/@me/nick", "guild.id");
-    public static final Route REMOVE_GUILD_MEMBER                 = new Route(DELETE, "/guilds/{guild.id}/members/{user.id}", "guild.id");
-    public static final Route GET_GUILD_MEMBER                    = new Route(GET,    "/guilds/{guild.id}/members/{user.id}", "guild.id");
-    public static final Route MODIFY_GUILD_MEMBER                 = new Route(PATCH,  "/guilds/{guild.id}/members/{user.id}", "guild.id");
-    public static final Route ADD_GUILD_MEMBER                    = new Route(PUT,    "/guilds/{guild.id}/members/{user.id}", "guild.id");
-    public static final Route REMOVE_GUILD_MEMBER_ROLE            = new Route(DELETE, "/guilds/{guild.id}/members/{user.id}/roles/{role.id}", "guild.id");
-    public static final Route ADD_GUILD_MEMBER_ROLE               = new Route(PUT,    "/guilds/{guild.id}/members/{user.id}/roles/{role.id}", "guild.id");
-    public static final Route GET_GUILD_PRUNE_COUNT               = new Route(GET,    "/guilds/{guild.id}/prune", "guild.id");
-    public static final Route BEGIN_GUILD_PRUNE                   = new Route(POST,   "/guilds/{guild.id}/prune", "guild.id");
-    public static final Route GET_GUILD_VOICE_REGIONS             = new Route(GET,    "/guilds/{guild.id}/regions", "guild.id");
-    public static final Route GET_GUILD_ROLES                     = new Route(GET,    "/guilds/{guild.id}/roles", "guild.id");
-    public static final Route MODIFY_GUILD_ROLE_POSITIONS         = new Route(PATCH,  "/guilds/{guild.id}/roles", "guild.id");
-    public static final Route CREATE_GUILD_ROLE                   = new Route(POST,   "/guilds/{guild.id}/roles", "guild.id");
-    public static final Route DELETE_GUILD_ROLE                   = new Route(DELETE, "/guilds/{guild.id}/roles/{role.id}", "guild.id");
-    public static final Route MODIFY_GUILD_ROLE                   = new Route(PATCH,  "/guilds/{guild.id}/roles/{role.id}", "guild.id");
-    public static final Route GET_GUILD_WEBHOOKS                  = new Route(GET,    "/guilds/{guild.id}/webhooks", "guild.id");
-    public static final Route GET_WEBHOOK                         = new Route(GET,    "/webhooks/{webhook.id}", "webhook.id");
-    public static final Route MODIFY_WEBHOOK                      = new Route(PATCH,  "/webhooks/{webhook.id}", "webhook.id");
-    public static final Route DELETE_WEBHOOK                      = new Route(DELETE, "/webhooks/{webhook.id}", "webhook.id");
-    public static final Route GET_WEBHOOK_TOKEN                   = new Route(GET,    "/webhooks/{webhook.id}/{webhook.token}", "webhook.id");
-    public static final Route EXECUTE_WEBHOOK                     = new Route(POST,   "/webhooks/{webhook.id}/{webhook.token}", "webhook.id");
-    public static final Route DELETE_INVITE                       = new Route(DELETE, "/invites/{invite.code}");
-    public static final Route GET_INVITE                          = new Route(GET,    "/invites/{invite.code}");
-    public static final Route ACCEPT_INVITE                       = new Route(POST,   "/invites/{invite.code}");
+    public static final Route DELETE_GUILD                        = new Route(DELETE, "/guilds/:guild", "guild");
+    public static final Route GET_GUILD                           = new Route(GET,    "/guilds/:guild", "guild");
+    public static final Route MODIFY_GUILD                        = new Route(PATCH,  "/guilds/:guild", "guild");
+    public static final Route GET_GUILD_AUDIT_LOG                 = new Route(GET,    "/guilds/:guild/audit-logs", "guild");
+    public static final Route GET_GUILD_BANS                      = new Route(GET,    "/guilds/:guild/bans", "guild");
+    public static final Route GET_GUILD_BAN                       = new Route(GET,    "/guilds/:guild/bans/:user", "guild");
+    public static final Route REMOVE_GUILD_BAN                    = new Route(DELETE, "/guilds/:guild/bans/:user", "guild");
+    public static final Route CREATE_GUILD_BAN                    = new Route(PUT,    "/guilds/:guild/bans/:user", "guild");
+    public static final Route GET_GUILD_CHANNELS                  = new Route(GET,    "/guilds/:guild/channels", "guild");
+    public static final Route MODIFY_GUILD_CHANNEL_POSITIONS      = new Route(PATCH,  "/guilds/:guild/channels", "guild");
+    public static final Route CREATE_GUILD_CHANNEL                = new Route(POST,   "/guilds/:guild/channels", "guild");
+    public static final Route GET_GUILD_EMBED                     = new Route(GET,    "/guilds/:guild/embed", "guild");
+    public static final Route MODIFY_GUILD_EMBED                  = new Route(PATCH,  "/guilds/:guild/embed", "guild");
+    public static final Route LIST_GUILD_EMOJIS                   = new Route(GET,    "/guilds/:guild/emojis", "guild");
+    public static final Route GET_GUILD_EMOJI                     = new Route(GET,    "/guilds/:guild/emojis/:emojis", "guild");
+    public static final Route CREATE_GUILD_EMOJI                  = new Route(POST,   "/guilds/:guild/emojis", "guild");
+    public static final Route MODIFY_GUILD_EMOJI                  = new Route(PATCH,  "/guilds/:guild/emojis/:emojis", "guild");
+    public static final Route DELETE_GUILD_EMOJI                  = new Route(DELETE, "/guilds/:guild/emojis/:emojis", "guild");
+    public static final Route GET_GUILD_INTEGRATIONS              = new Route(GET,    "/guilds/:guild/integrations", "guild");
+    public static final Route CREATE_GUILD_INTEGRATION            = new Route(POST,   "/guilds/:guild/integrations", "guild");
+    public static final Route DELETE_GUILD_INTEGRATION            = new Route(DELETE, "/guilds/:guild/integrations/:integration", "guild");
+    public static final Route MODIFY_GUILD_INTEGRATION            = new Route(PATCH,  "/guilds/:guild/integrations/:integration", "guild");
+    public static final Route SYNC_GUILD_INTEGRATION              = new Route(POST,   "/guilds/:guild/integrations/:integration/sync", "guild");
+    public static final Route GET_GUILD_INVITES                   = new Route(GET,    "/guilds/:guild/invites", "guild");
+    public static final Route LIST_GUILD_MEMBERS                  = new Route(GET,    "/guilds/:guild/members", "guild");
+    public static final Route MODIFY_CURRENT_USERS_NICK           = new Route(PATCH,  "/guilds/:guild/members/@me/nick", "guild");
+    public static final Route REMOVE_GUILD_MEMBER                 = new Route(DELETE, "/guilds/:guild/members/:user", "guild");
+    public static final Route GET_GUILD_MEMBER                    = new Route(GET,    "/guilds/:guild/members/:user", "guild");
+    public static final Route MODIFY_GUILD_MEMBER                 = new Route(PATCH,  "/guilds/:guild/members/:user", "guild");
+    public static final Route ADD_GUILD_MEMBER                    = new Route(PUT,    "/guilds/:guild/members/:user", "guild");
+    public static final Route REMOVE_GUILD_MEMBER_ROLE            = new Route(DELETE, "/guilds/:guild/members/:user/roles/:role", "guild");
+    public static final Route ADD_GUILD_MEMBER_ROLE               = new Route(PUT,    "/guilds/:guild/members/:user/roles/:role", "guild");
+    public static final Route GET_GUILD_PRUNE_COUNT               = new Route(GET,    "/guilds/:guild/prune", "guild");
+    public static final Route BEGIN_GUILD_PRUNE                   = new Route(POST,   "/guilds/:guild/prune", "guild");
+    public static final Route GET_GUILD_VOICE_REGIONS             = new Route(GET,    "/guilds/:guild/regions", "guild");
+    public static final Route GET_GUILD_ROLES                     = new Route(GET,    "/guilds/:guild/roles", "guild");
+    public static final Route MODIFY_GUILD_ROLE_POSITIONS         = new Route(PATCH,  "/guilds/:guild/roles", "guild");
+    public static final Route CREATE_GUILD_ROLE                   = new Route(POST,   "/guilds/:guild/roles", "guild");
+    public static final Route DELETE_GUILD_ROLE                   = new Route(DELETE, "/guilds/:guild/roles/:role", "guild");
+    public static final Route MODIFY_GUILD_ROLE                   = new Route(PATCH,  "/guilds/:guild/roles/:role", "guild");
+    public static final Route GET_GUILD_WEBHOOKS                  = new Route(GET,    "/guilds/:guild/webhooks", "guild");
+    public static final Route GET_WEBHOOK                         = new Route(GET,    "/webhooks/:webhook", "webhook");
+    public static final Route MODIFY_WEBHOOK                      = new Route(PATCH,  "/webhooks/:webhook", "webhook");
+    public static final Route DELETE_WEBHOOK                      = new Route(DELETE, "/webhooks/:webhook", "webhook");
+    public static final Route GET_WEBHOOK_TOKEN                   = new Route(GET,    "/webhooks/:webhook/:token", "webhook");
+    public static final Route EXECUTE_WEBHOOK                     = new Route(POST,   "/webhooks/:webhook/:token", "webhook");
+    public static final Route DELETE_INVITE                       = new Route(DELETE, "/invites/:invite");
+    public static final Route GET_INVITE                          = new Route(GET,    "/invites/:invite");
+    public static final Route ACCEPT_INVITE                       = new Route(POST,   "/invites/:invite");
     public static final Route GET_CURRENT_USER                    = new Route(GET,    "/users/@me");
     public static final Route MODIFY_CURRENT_USER                 = new Route(PATCH,  "/users/@me");
     public static final Route GET_USER_DMS                        = new Route(GET,    "/users/@me/channels");
     public static final Route CREATE_DM                           = new Route(POST,   "/users/@me/channels");
     public static final Route GET_CURRENT_USER_GUILDS             = new Route(GET,    "/users/@me/guilds");
-    public static final Route LEAVE_GUILD                         = new Route(DELETE, "/users/@me/guilds/{guild.id}");
-    public static final Route GET_USER                            = new Route(GET,    "/users/{user.id}");
+    public static final Route LEAVE_GUILD                         = new Route(DELETE, "/users/@me/guilds/:guild");
+    public static final Route GET_USER                            = new Route(GET,    "/users/:user");
     public static final Route GET_CURRENT_APPLICATION_INFORMATION = new Route(GET,    "/oauth2/applications/@me");
     public static final Route LIST_VOICE_REGIONS                  = new Route(GET,    "/voice/regions");
+    // @formatter:on
 
     private Routes() {
     }
@@ -171,7 +172,7 @@ public final class Routes {
             if(majorParam == null) {
                 throw new IllegalStateException("This route takes no major params!");
             }
-            final String majorParamString = '{' + majorParam + '}';
+            final String majorParamString = ':' + majorParam;
             return new Route(method, baseRoute.replace(majorParamString, value), null,
                     baseRoute.replace(majorParamString, value));
         }
@@ -182,7 +183,7 @@ public final class Routes {
             if(param.equalsIgnoreCase(majorParam)) {
                 return this;
             }
-            return new Route(method, baseRoute.replace('{' + param + '}', value), majorParam, ratelimitKey);
+            return new Route(method, baseRoute.replace(':' + param, value), majorParam, ratelimitKey);
         }
         
         @Nonnull
@@ -213,5 +214,4 @@ public final class Routes {
             return method + " " + baseRoute;
         }
     }
-    // @formatter:on
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestChannel.java
@@ -150,7 +150,7 @@ public class RestChannel extends RestHandler {
     public Observable<JsonObject> getMessageRaw(@Nonnull final String channelId, @Nonnull final String messageId) {
         return catnip().requester().queue(
                 new OutboundRequest(Routes.GET_CHANNEL_MESSAGE.withMajorParam(channelId),
-                        Map.of("message.id", messageId)))
+                        Map.of("message", messageId)))
                 .map(ResponsePayload::object);
     }
     
@@ -188,7 +188,7 @@ public class RestChannel extends RestHandler {
         }
         return catnip().requester()
                 .queue(new OutboundRequest(Routes.EDIT_MESSAGE.withMajorParam(channelId),
-                        Map.of("message.id", messageId), json))
+                        Map.of("message", messageId), json))
                 .map(ResponsePayload::object);
     }
     
@@ -196,7 +196,7 @@ public class RestChannel extends RestHandler {
     public Completable deleteMessage(@Nonnull final String channelId, @Nonnull final String messageId,
                                      @Nullable final String reason) {
         return catnip().requester().queue(new OutboundRequest(Routes.DELETE_MESSAGE.withMajorParam(channelId),
-                Map.of("message.id", messageId)).reason(reason))
+                Map.of("message", messageId)).reason(reason))
                 .ignoreElements();
     }
     
@@ -223,7 +223,7 @@ public class RestChannel extends RestHandler {
     public Completable addReaction(@Nonnull final String channelId, @Nonnull final String messageId,
                                    @Nonnull final String emoji) {
         return catnip().requester().queue(new OutboundRequest(Routes.CREATE_REACTION.withMajorParam(channelId),
-                Map.of("message.id", messageId, "emojis", encodeUTF8(emoji)), new JsonObject()))
+                Map.of("message", messageId, "emojis", encodeUTF8(emoji)), new JsonObject()))
                 .ignoreElements();
     }
     
@@ -238,7 +238,7 @@ public class RestChannel extends RestHandler {
                                          @Nonnull final String emoji) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.DELETE_OWN_REACTION.withMajorParam(channelId),
-                        Map.of("message.id", messageId, "emojis", encodeUTF8(emoji))).emptyBody(true)));
+                        Map.of("message", messageId, "emojis", encodeUTF8(emoji))).emptyBody(true)));
     }
     
     @Nonnull
@@ -252,7 +252,7 @@ public class RestChannel extends RestHandler {
                                           @Nonnull final String userId, @Nonnull final String emoji) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.DELETE_USER_REACTION.withMajorParam(channelId),
-                        Map.of("message.id", messageId, "emojis", encodeUTF8(emoji), "user.id", userId))
+                        Map.of("message", messageId, "emojis", encodeUTF8(emoji), "user", userId))
                         .emptyBody(true)));
     }
     
@@ -266,7 +266,7 @@ public class RestChannel extends RestHandler {
     public Completable deleteAllReactions(@Nonnull final String channelId, @Nonnull final String messageId) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.DELETE_ALL_REACTIONS.withMajorParam(channelId),
-                        Map.of("message.id", messageId)).emptyBody(true)));
+                        Map.of("message", messageId)).emptyBody(true)));
     }
     
     @Nonnull
@@ -312,7 +312,7 @@ public class RestChannel extends RestHandler {
         final String query = builder.build();
         return catnip().requester()
                 .queue(new OutboundRequest(Routes.GET_REACTIONS.withMajorParam(channelId).withQueryString(query),
-                        Map.of("message.id", messageId, "emojis", encodeUTF8(emoji))))
+                        Map.of("message", messageId, "emojis", encodeUTF8(emoji))))
                 .map(ResponsePayload::array);
     }
     
@@ -494,7 +494,7 @@ public class RestChannel extends RestHandler {
                                                 @Nonnull final String overwriteId, @Nullable final String reason) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.DELETE_CHANNEL_PERMISSION.withMajorParam(channelId),
-                        Map.of("overwrite.id", overwriteId)).reason(reason).emptyBody(true)));
+                        Map.of("overwrite", overwriteId)).reason(reason).emptyBody(true)));
     }
     
     @Nonnull
@@ -517,7 +517,7 @@ public class RestChannel extends RestHandler {
                                               final boolean isMember, @Nullable final String reason) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.EDIT_CHANNEL_PERMISSIONS.withMajorParam(channelId),
-                        Map.of("overwrite.id", overwriteId), JsonObject.builder()
+                        Map.of("overwrite", overwriteId), JsonObject.builder()
                         .value("allow", Permission.from(allowed))
                         .value("deny", Permission.from(denied))
                         .value("type", isMember ? "member" : "role")
@@ -575,7 +575,7 @@ public class RestChannel extends RestHandler {
     public Completable deletePinnedMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.DELETE_PINNED_CHANNEL_MESSAGE.withMajorParam(channelId),
-                        Map.of("message.id", messageId)).emptyBody(true)));
+                        Map.of("message", messageId)).emptyBody(true)));
     }
     
     @Nonnull
@@ -586,7 +586,7 @@ public class RestChannel extends RestHandler {
     @Nonnull
     public Completable addPinnedMessage(@Nonnull final String channelId, @Nonnull final String messageId) {
         return catnip().requester().queue(new OutboundRequest(Routes.ADD_PINNED_CHANNEL_MESSAGE.withMajorParam(channelId),
-                Map.of("message.id", messageId), new JsonObject()))
+                Map.of("message", messageId), new JsonObject()))
                 .ignoreElements();
     }
     

--- a/src/main/java/com/mewna/catnip/rest/handler/RestEmoji.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestEmoji.java
@@ -84,7 +84,7 @@ public class RestEmoji extends RestHandler {
         return catnip().requester().queue(
                 new OutboundRequest(
                         Routes.GET_GUILD_EMOJI.withMajorParam(guildId),
-                        Map.of("emojis.id", emojiId)))
+                        Map.of("emojis", emojiId)))
                 .map(ResponsePayload::object);
     }
     
@@ -180,7 +180,7 @@ public class RestEmoji extends RestHandler {
         return catnip().requester().queue(
                 new OutboundRequest(
                         Routes.MODIFY_GUILD_EMOJI.withMajorParam(guildId),
-                        Map.of("emojis.id", emojiId),
+                        Map.of("emojis", emojiId),
                         JsonObject.builder()
                                 .value("name", name)
                                 .value("roles", rolesArray)
@@ -196,7 +196,7 @@ public class RestEmoji extends RestHandler {
         return Completable.fromObservable(catnip().requester().queue(
                 new OutboundRequest(
                         Routes.DELETE_GUILD_EMOJI.withMajorParam(guildId),
-                        Map.of("emojis.id", emojiId)).reason(reason).emptyBody(true)));
+                        Map.of("emojis", emojiId)).reason(reason).emptyBody(true)));
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestGuild.java
@@ -73,7 +73,7 @@ public class RestGuild extends RestHandler {
                                          @Nonnull final MemberData data, @Nullable final String reason) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.MODIFY_GUILD_MEMBER.withMajorParam(guildId),
-                        Map.of("user.id", memberId), data.toJson(), reason)));
+                        Map.of("user", memberId), data.toJson(), reason)));
     }
     
     @Nonnull
@@ -230,7 +230,7 @@ public class RestGuild extends RestHandler {
                                                      @Nonnull final RoleData roleData, @Nullable final String reason) {
         return catnip().requester()
                 .queue(new OutboundRequest(Routes.MODIFY_GUILD_ROLE.withMajorParam(guildId),
-                        Map.of("role.id", roleId), roleData.toJson(), reason))
+                        Map.of("role", roleId), roleData.toJson(), reason))
                 .map(ResponsePayload::object);
     }
     
@@ -240,7 +240,7 @@ public class RestGuild extends RestHandler {
                                        @Nullable final String reason) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.DELETE_GUILD_ROLE.withMajorParam(guildId),
-                        Map.of("role.id", roleId)).reason(reason).emptyBody(true)));
+                        Map.of("role", roleId)).reason(reason).emptyBody(true)));
     }
     
     @Nonnull
@@ -424,7 +424,7 @@ public class RestGuild extends RestHandler {
     @CheckReturnValue
     public Observable<JsonObject> getGuildBanRaw(@Nonnull final String guildId, @Nonnull final String userId) {
         return catnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_BAN.withMajorParam(guildId),
-                Map.of("user.id", userId)))
+                Map.of("user", userId)))
                 .map(ResponsePayload::object);
     }
     
@@ -444,7 +444,7 @@ public class RestGuild extends RestHandler {
         final String query = builder.build();
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.CREATE_GUILD_BAN.withMajorParam(guildId).withQueryString(query),
-                        Map.of("user.id", userId)).reason(reason).emptyBody(true)));
+                        Map.of("user", userId)).reason(reason).emptyBody(true)));
     }
     
     @Nonnull
@@ -458,7 +458,7 @@ public class RestGuild extends RestHandler {
                                       @Nullable final String reason) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.REMOVE_GUILD_BAN.withMajorParam(guildId),
-                        Map.of("user.id", userId)).reason(reason).emptyBody(true)));
+                        Map.of("user", userId)).reason(reason).emptyBody(true)));
     }
     
     @Nonnull
@@ -485,7 +485,7 @@ public class RestGuild extends RestHandler {
                                          @Nullable final String reason) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.REMOVE_GUILD_MEMBER.withMajorParam(guildId),
-                        Map.of("user.id", userId)).reason(reason).emptyBody(true)));
+                        Map.of("user", userId)).reason(reason).emptyBody(true)));
     }
     
     @Nonnull
@@ -504,7 +504,7 @@ public class RestGuild extends RestHandler {
     @CheckReturnValue
     public Observable<JsonObject> getGuildMemberRaw(@Nonnull final String guildId, @Nonnull final String userId) {
         return catnip().requester().queue(new OutboundRequest(Routes.GET_GUILD_MEMBER.withMajorParam(guildId),
-                Map.of("user.id", userId)))
+                Map.of("user", userId)))
                 .map(ResponsePayload::object);
     }
     
@@ -513,7 +513,7 @@ public class RestGuild extends RestHandler {
                                              @Nonnull final String roleId, @Nullable final String reason) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.REMOVE_GUILD_MEMBER_ROLE.withMajorParam(guildId),
-                        Map.of("user.id", userId, "role.id", roleId)).reason(reason).emptyBody(true)));
+                        Map.of("user", userId, "role", roleId)).reason(reason).emptyBody(true)));
     }
     
     @Nonnull
@@ -527,7 +527,7 @@ public class RestGuild extends RestHandler {
                                           @Nonnull final String roleId, @Nullable final String reason) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.ADD_GUILD_MEMBER_ROLE.withMajorParam(guildId),
-                        Map.of("user.id", userId, "role.id", roleId)).reason(reason).emptyBody(true)));
+                        Map.of("user", userId, "role", roleId)).reason(reason).emptyBody(true)));
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/rest/handler/RestInvite.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestInvite.java
@@ -61,7 +61,7 @@ public class RestInvite extends RestHandler {
     @CheckReturnValue
     public Observable<JsonObject> getInviteRaw(@Nonnull final String code) {
         return catnip().requester().queue(new OutboundRequest(Routes.GET_INVITE,
-                Map.of("invite.code", code)))
+                Map.of("invite", code)))
                 .map(ResponsePayload::object);
     }
     
@@ -81,7 +81,7 @@ public class RestInvite extends RestHandler {
     @CheckReturnValue
     public Observable<JsonObject> deleteInviteRaw(@Nonnull final String code, @Nullable final String reason) {
         return catnip().requester().queue(new OutboundRequest(Routes.DELETE_INVITE,
-                Map.of("invite.code", code)).reason(reason))
+                Map.of("invite", code)).reason(reason))
                 .map(ResponsePayload::object);
     }
 }

--- a/src/main/java/com/mewna/catnip/rest/handler/RestUser.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestUser.java
@@ -87,7 +87,7 @@ public class RestUser extends RestHandler {
     @CheckReturnValue
     public Observable<JsonObject> getUserRaw(@Nonnull final String userId) {
         return catnip().requester().queue(new OutboundRequest(Routes.GET_USER,
-                Map.of("user.id", userId)))
+                Map.of("user", userId)))
                 .map(ResponsePayload::object);
     }
     
@@ -179,7 +179,7 @@ public class RestUser extends RestHandler {
     public Completable leaveGuild(@Nonnull final String guildId) {
         return Completable.fromObservable(catnip().requester()
                 .queue(new OutboundRequest(Routes.LEAVE_GUILD,
-                        Map.of("guild.id", guildId)).emptyBody(true)));
+                        Map.of("guild", guildId)).emptyBody(true)));
     }
     
     @Nonnull

--- a/src/main/java/com/mewna/catnip/rest/handler/RestWebhook.java
+++ b/src/main/java/com/mewna/catnip/rest/handler/RestWebhook.java
@@ -82,7 +82,7 @@ public class RestWebhook extends RestHandler {
     @CheckReturnValue
     public Observable<JsonObject> getWebhookTokenRaw(@Nonnull final String webhookId, @Nonnull final String token) {
         return catnip().requester().queue(new OutboundRequest(Routes.GET_WEBHOOK_TOKEN.withMajorParam(webhookId),
-                Map.of("webhook.token", token)))
+                Map.of("webhook", token)))
                 .map(ResponsePayload::object);
     }
     
@@ -204,7 +204,7 @@ public class RestWebhook extends RestHandler {
         
         return catnip().requester().
                 queue(new OutboundRequest(Routes.EXECUTE_WEBHOOK.withMajorParam(webhookId).withQueryString("?wait=true"),
-                        Map.of("webhook.token", webhookToken), body).needsToken(false)
+                        Map.of("webhook", webhookToken), body).needsToken(false)
                         .buffers(options.files()))
                 .map(ResponsePayload::object);
     }


### PR DESCRIPTION
The reasoning behind this is that, while it's nice to have the routes follow the same format as the official docs, it's also a bit annoying to have `{}` in the parameters, as it makes things like using the route objects directly to make a REST proxy or similar a bit annoying. By changing to use `:params` instead, the routes become more in-line with what many common libraries/frameworks expect, and don't require any pre/post-processing in order to be usable (ex. because a library doesn't allow for `{}` in routes, or only uses `:params` for dynamic route params).