### PR TITLE
Fix role hierarchy check by using descending sort

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/guild/Member.java
+++ b/src/main/java/com/mewna/catnip/entity/guild/Member.java
@@ -118,6 +118,12 @@ public interface Member extends Mentionable, PermissionHolder {
     @Nonnull
     @CheckReturnValue
     default List<Role> orderedRoles() {
+        return orderedRoles(Comparator.naturalOrder());
+    }
+    
+    @Nonnull
+    @CheckReturnValue
+    default List<Role> orderedRoles(final Comparator<Role> comparator) {
         final CacheView<Role> roles = catnip().cache().roles(guildId());
         final List<Role> ordered = new ArrayList<>(roleIds().size());
         for(final String id : roleIds()) {
@@ -126,7 +132,7 @@ public interface Member extends Mentionable, PermissionHolder {
                 ordered.add(role);
             }
         }
-        Collections.sort(ordered);
+        ordered.sort(comparator);
         return ordered;
     }
     

--- a/src/main/java/com/mewna/catnip/util/PermissionUtil.java
+++ b/src/main/java/com/mewna/catnip/util/PermissionUtil.java
@@ -38,6 +38,7 @@ import com.mewna.catnip.entity.util.Permission;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Comparator;
 
 public final class PermissionUtil {
     private PermissionUtil() {
@@ -242,7 +243,7 @@ public final class PermissionUtil {
             return actor.isOwner();
         }
         // Check if the highest role of the actor is higher than the role of the target
-        return canInteract(actor.orderedRoles().iterator().next(), target);
+        return canInteract(actor.orderedRoles(Comparator.reverseOrder()).iterator().next(), target);
     }
     
     /**

--- a/src/main/java/com/mewna/catnip/util/PermissionUtil.java
+++ b/src/main/java/com/mewna/catnip/util/PermissionUtil.java
@@ -38,6 +38,7 @@ import com.mewna.catnip.entity.util.Permission;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 
 public final class PermissionUtil {
@@ -202,7 +203,7 @@ public final class PermissionUtil {
         if(actor.orderedRoles().isEmpty()) {
             return actor.isOwner();
         }
-        return canInteract(actor.orderedRoles().iterator().next(), target);
+        return canInteract(actor.orderedRoles(Collections.reverseOrder()).iterator().next(), target);
     }
     
     /**
@@ -222,7 +223,7 @@ public final class PermissionUtil {
         if(target.orderedRoles().isEmpty()) {
             return true;
         }
-        return canInteract(actor, target.orderedRoles().iterator().next());
+        return canInteract(actor, target.orderedRoles(Comparator.reverseOrder()).iterator().next());
     }
     
     /**


### PR DESCRIPTION
Before this PR, we were retrieving lowest role in hierarchy, because without specifying comparator in `Collections.sort()` underlying implementation will sort collection with natural order. This change implements ability to specify comparator that will be used while retrieving collection of ordered roles. This PR also fixes role hierarchy check that affects #340.