### PR TITLE
Fixed link for Stats Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ where `JsonPojoCodec` is `com.mewna.catnip.util.JsonPojoCodec` and is safe to us
 - `catnip-utilities` - Some extensions for typesafe commands, event waiters, reaction menus, 
   and more. https://github.com/queer/catnip-utilities 
 - `discordbotlist-stats-catnip` - Wrapper aiming at combining all Discord Bot Lists AND Wrappers into one artifact.
-  Automatically handles pushing bot stats to bot lists. https://github.com/burdoto/discordbotlist-stats#usage-example-catnip
+  Automatically handles pushing bot stats to bot lists. https://github.com/burdoto/discordbotlist-stats#using-with-catnip--
 
 ## Why write a fourth Java lib?
 


### PR DESCRIPTION
Due to recent updating of the README file of `discordbotlist-stats`, the old URL will not redirect to the Catnip explanation part of the README anymore. This change fixes that.