### PR TITLE
Add missing "Video" permission & general changes

### DIFF
--- a/src/main/java/com/mewna/catnip/entity/guild/Guild.java
+++ b/src/main/java/com/mewna/catnip/entity/guild/Guild.java
@@ -808,7 +808,7 @@ public interface Guild extends Snowflake {
     @Nonnull
     default Single<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final byte[] image,
                                             @Nonnull final Collection<String> roles, @Nullable final String reason) {
-        PermissionUtil.checkPermissions(catnip(), id(), Permission.MANAGE_EMOJI);
+        PermissionUtil.checkPermissions(catnip(), id(), Permission.MANAGE_EMOJIS);
         return catnip().rest().emoji().createGuildEmoji(id(), name, image, roles, reason);
     }
     
@@ -840,7 +840,7 @@ public interface Guild extends Snowflake {
     @Nonnull
     default Single<CustomEmoji> createEmoji(@Nonnull final String name, @Nonnull final URI imageData,
                                             @Nonnull final Collection<String> roles, @Nullable final String reason) {
-        PermissionUtil.checkPermissions(catnip(), id(), Permission.MANAGE_EMOJI);
+        PermissionUtil.checkPermissions(catnip(), id(), Permission.MANAGE_EMOJIS);
         return catnip().rest().emoji().createGuildEmoji(id(), name, imageData, roles, reason);
     }
     
@@ -873,7 +873,7 @@ public interface Guild extends Snowflake {
     @Nonnull
     default Single<CustomEmoji> modifyEmoji(@Nonnull final String emojiId, @Nonnull final String name,
                                             @Nonnull final Collection<String> roles, @Nullable final String reason) {
-        PermissionUtil.checkPermissions(catnip(), id(), Permission.MANAGE_EMOJI);
+        PermissionUtil.checkPermissions(catnip(), id(), Permission.MANAGE_EMOJIS);
         return catnip().rest().emoji().modifyGuildEmoji(id(), emojiId, name, roles, reason);
     }
     
@@ -903,7 +903,7 @@ public interface Guild extends Snowflake {
      */
     @Nonnull
     default Completable deleteEmoji(@Nonnull final String emojiId, @Nullable final String reason) {
-        PermissionUtil.checkPermissions(catnip(), id(), Permission.MANAGE_EMOJI);
+        PermissionUtil.checkPermissions(catnip(), id(), Permission.MANAGE_EMOJIS);
         return catnip().rest().emoji().deleteGuildEmoji(id(), emojiId, reason);
     }
     

--- a/src/main/java/com/mewna/catnip/entity/util/Permission.java
+++ b/src/main/java/com/mewna/catnip/entity/util/Permission.java
@@ -47,7 +47,9 @@ public enum Permission {
     MANAGE_CHANNELS(0x00000010, true, "Manage Channels"),
     MANAGE_GUILD(0x00000020, false, "Manage Server"),
     ADD_REACTIONS(0x00000040, true, "Add Reactions"),
-    VIEW_AUDIT_LOG(0x00000080, false, "View Audit Logs"),
+    VIEW_AUDIT_LOG(0x00000080, false, "View Audit Log"),
+    PRIORITY_SPEAKER(0x00000100, true, "Priority Speaker"),
+    STREAM(0x00000200, true, "Video"),
     VIEW_CHANNEL(0x00000400, true, "Read Text Channels & See Voice Channels"),
     SEND_MESSAGES(0x00000800, true, "Send Messages"),
     SEND_TTS_MESSAGES(0x00001000, true, "Send TTS Messages"),
@@ -55,20 +57,20 @@ public enum Permission {
     EMBED_LINKS(0x00004000, true, "Embed Links"),
     ATTACH_FILES(0x00008000, true, "Attach Files"),
     READ_MESSAGE_HISTORY(0x00010000, true, "Read History"),
-    MENTION_EVERYONE(0x00020000, true, "Mention Everyone"),
-    USE_EXTERNAL_EMOJI(0x00040000, true, "Use External Emojis"),
+    MENTION_EVERYONE(0x00020000, true, "Mention @everyone, @here and All Roles"),
+    USE_EXTERNAL_EMOJIS(0x00040000, true, "Use External Emojis"),
+    VIEW_GUILD_INSIGHTS(0x00080000, false, "View Server Insights"),
     CONNECT(0x00100000, true, "Connect"),
     SPEAK(0x00200000, true, "Speak"),
     MUTE_MEMBERS(0x00400000, true, "Mute Members"),
     DEAFEN_MEMBERS(0x00800000, true, "Deafen Members"),
     MOVE_MEMBERS(0x01000000, true, "Move Members"),
     USE_VAD(0x02000000, true, "Use Voice Activity"),
-    PRIORITY_SPEAKER(0x00000100, true, "Priority Speaker"),
     CHANGE_NICKNAME(0x04000000, false, "Change Nickname"),
-    MANAGE_NICKNAME(0x08000000, false, "Manage Nicknames"),
+    MANAGE_NICKNAMES(0x08000000, false, "Manage Nicknames"),
     MANAGE_ROLES(0x10000000, true, "Manage Roles"),
     MANAGE_WEBHOOKS(0x20000000, true, "Manage Webhooks"),
-    MANAGE_EMOJI(0x40000000, false, "Manage Emojis");
+    MANAGE_EMOJIS(0x40000000, false, "Manage Emojis");
     
     public static final long ALL = from(Permission.values());
     public static final long NONE = 0;

--- a/src/test/java/com/mewna/catnip/permission/BitwiseTest.java
+++ b/src/test/java/com/mewna/catnip/permission/BitwiseTest.java
@@ -44,7 +44,7 @@ public class BitwiseTest {
     @Test
     public void testAll() {
         final Permission[] perms = values();
-        final int expected = 2146958847;
+        final int expected = 2147483647;
         int total = 0;
         
         for(final Permission p : perms) {


### PR DESCRIPTION
- Add missing "Video" (`STREAM`) permission
- Add missing "View Server Insights" (`VIEW_GUILD_INSIGHTS`) permission
- Change permName of `MENTION_EVERYONE` from `Mention Everyone` to `Mention @everyone, @here and All Roles` to match up with the name in the Discord client
- Change permName of `VIEW_AUDIT_LOG` from `View Audit Logs` to `View Audit Log` to match up with the name in the Discord client
- Change enum names of `MANAGE_NICKNAME` to `MANAGE_NICKNAMES`, as well as `MANAGE_EMOJI` to `MANAGE_EMOJIS` and `USE_EXTERNAL_EMOJI` to `USE_EXTERNAL_EMOJIS` to match up with the Discord documentation at https://discordapp.com/developers/docs/topics/permissions
- Move `PRIORITY_SPEAKER` further up to make the Permission enum match up with the list provided by the already mentioned Discord documentation